### PR TITLE
Increase SAM MemorySize and Timeout

### DIFF
--- a/aws-kendra-data-source/template.yml
+++ b/aws-kendra-data-source/template.yml
@@ -4,7 +4,8 @@ Description: AWS SAM template for the AWS::Kendra::DataSource resource type
 
 Globals:
   Function:
-    Timeout: 60  # docker start-up times can be long for SAM CLI
+    Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
 
 Resources:
   TypeFunction:

--- a/aws-kendra-faq/template.yml
+++ b/aws-kendra-faq/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::Kendra::Faq resource type
 Globals:
   Function:
     Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
 
 Resources:
   TypeFunction:

--- a/aws-kendra-index/template.yml
+++ b/aws-kendra-index/template.yml
@@ -5,6 +5,7 @@ Description: AWS SAM template for the AWS::Kendra::Index resource type
 Globals:
   Function:
     Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
 
 Resources:
   TypeFunction:


### PR DESCRIPTION
### Notes
- Increasing memory given to the local docker lambda service. See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html

### Testing
- Ran ```cfn test --enforce-timeout 180 -- -k contract_create_delete``` and it passed for the first time