### PR TITLE
Add kendra:TagResource permission to all create handlers

### DIFF
--- a/aws-kendra-data-source/aws-kendra-datasource.json
+++ b/aws-kendra-data-source/aws-kendra-datasource.json
@@ -319,7 +319,8 @@
         "kendra:CreateDataSource",
         "kendra:DescribeDataSource",
         "kendra:ListTagsForResource",
-        "iam:PassRole"
+        "iam:PassRole",
+        "kendra:TagResource"
       ]
     },
     "read": {

--- a/aws-kendra-faq/aws-kendra-faq.json
+++ b/aws-kendra-faq/aws-kendra-faq.json
@@ -135,7 +135,8 @@
         "kendra:CreateFaq",
         "kendra:DescribeFaq",
         "iam:PassRole",
-        "kendra:ListTagsForResource"
+        "kendra:ListTagsForResource",
+        "kendra:TagResource"
       ]
     },
     "update": {

--- a/aws-kendra-index/aws-kendra-index.json
+++ b/aws-kendra-index/aws-kendra-index.json
@@ -264,7 +264,8 @@
         "kendra:DescribeIndex",
         "kendra:UpdateIndex",
         "kendra:ListTagsForResource",
-        "iam:PassRole"
+        "iam:PassRole",
+        "kendra:TagResource"
       ],
       "timeoutInMinutes": 240
     },


### PR DESCRIPTION
### Notes
- Our create APIs accept tags. If tags are provided the role needs ```TagResource``` permissions so adding them here
