### PR TITLE
Make various schema fixes

### DIFF
--- a/aws-kendra-data-source/aws-kendra-datasource.json
+++ b/aws-kendra-data-source/aws-kendra-datasource.json
@@ -125,7 +125,8 @@
     "SecretArn": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 1284
+      "maxLength": 1284,
+      "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
     },
     "DataSourceVpcConfiguration": {
       "type": "object",


### PR DESCRIPTION
### Notes
- The current pattern for ```DateFieldFormat``` is not compliant with draft-07 of JSON Schema which CloudFormation uses; this means we can't submit the data source handlers at all. Removing the restriction here. We'll still return a validation error to the customer if the format is wrong because we re-throw any 4xx we get from the service anyways
- Also adds SALESFORCE enum

### Testing
- ```cfn validate```
- ```cfn submit```