### PR TITLE
Adding validations for create only fields

### DIFF
--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/UpdateHandlerTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/UpdateHandlerTest.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.kendra.KendraClient;
 import software.amazon.awssdk.services.kendra.model.ConflictException;
@@ -24,6 +23,7 @@ import software.amazon.awssdk.services.kendra.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
@@ -56,6 +56,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
     private static final String TEST_DESCRIPTION = "testDescription";
     private static final String TEST_SCHEDULE = "testSchedule";
     private static final String TEST_DATA_SOURCE_TYPE = "testDataSourceType";
+    private static final String PREV_TEST_DATA_SOURCE_TYPE = "prevTestDataSourceType";
 
     TestDataSourceArnBuilder testDataSourceArnBuilder = new TestDataSourceArnBuilder();
 
@@ -74,13 +75,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         awsKendraClient = mock(KendraClient.class);
         proxyClient = MOCK_PROXY(proxy, awsKendraClient);
     }
-
-    @AfterEach
-    public void post_execute() {
-        verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
-    }
-
 
     @Test
     public void handleRequest_SimpleSuccess() {
@@ -147,6 +141,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateDataSource(any(UpdateDataSourceRequest.class));
         verify(proxyClient.client(), times(3)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
+
     }
 
     @Test
@@ -226,6 +224,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateDataSource(any(UpdateDataSourceRequest.class));
         verify(proxyClient.client(), times(4)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
+
     }
 
     @Test
@@ -253,6 +255,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
              handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
          });
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -280,6 +285,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
              handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
          });
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
+
     }
 
     @Test
@@ -307,6 +316,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
              handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
          });
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -334,6 +346,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
              handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
          });
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -407,6 +422,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(3)).describeDataSource(any(DescribeDataSourceRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -477,6 +495,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(3)).describeDataSource(any(DescribeDataSourceRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -560,6 +581,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -609,6 +633,9 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateDataSource(any(UpdateDataSourceRequest.class));
         verify(proxyClient.client(), times(2)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -659,5 +686,42 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateDataSource(any(UpdateDataSourceRequest.class));
         verify(proxyClient.client(), times(2)).describeDataSource(any(DescribeDataSourceRequest.class));
+
+        verify(awsKendraClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(awsKendraClient);
+    }
+
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException() {
+        final UpdateHandler handler = new UpdateHandler(testDataSourceArnBuilder);
+
+        final ResourceModel model = ResourceModel.builder()
+            .id(TEST_ID)
+            .indexId(TEST_INDEX_ID)
+            .name(TEST_DATA_SOURCE_NAME)
+            .schedule(TEST_SCHEDULE)
+            .roleArn(TEST_ROLE_ARN)
+            .description(TEST_DESCRIPTION)
+            .type(TEST_DATA_SOURCE_TYPE)
+            .build();
+
+        final ResourceModel prevModel = ResourceModel.builder()
+            .id(TEST_ID)
+            .indexId(TEST_INDEX_ID)
+            .name(TEST_DATA_SOURCE_NAME)
+            .schedule(TEST_SCHEDULE)
+            .roleArn(TEST_ROLE_ARN)
+            .description(TEST_DESCRIPTION)
+            .type(PREV_TEST_DATA_SOURCE_TYPE)
+            .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
     }
 }

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/UpdateHandler.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/UpdateHandler.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.kendra.model.TagResourceRequest;
 import software.amazon.awssdk.services.kendra.model.UntagResourceRequest;
 import software.amazon.awssdk.services.kendra.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -15,6 +16,7 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -42,6 +44,8 @@ public class UpdateHandler extends BaseHandlerStd {
         this.logger = logger;
 
         final ResourceModel model = request.getDesiredResourceState();
+
+        verifyNonUpdatableFields(model, request.getPreviousResourceState());
 
         // TODO: Adjust Progress Chain according to your implementation
         // https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/proxy/CallChain.java
@@ -91,6 +95,31 @@ public class UpdateHandler extends BaseHandlerStd {
         }
 
         return ProgressEvent.progress(resourceModel, callbackContext);
+    }
+
+   /**
+    * Checks the if the create only fields have been updated and throws an exception if it is the case
+    * @param currModel the current resource model
+    * @param prevModel the previous resource model
+    */
+    private void verifyNonUpdatableFields(ResourceModel currModel, ResourceModel prevModel) {
+        if (prevModel != null) {
+            if (!Optional.ofNullable(currModel.getIndexId()).equals(Optional.ofNullable(prevModel.getIndexId()))) {
+                throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, "IndexId");
+            }
+            if (!Optional.ofNullable(currModel.getName()).equals(Optional.ofNullable(prevModel.getName()))) {
+                throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, "Name");
+            }
+            if (!Optional.ofNullable(currModel.getS3Path()).equals(Optional.ofNullable(prevModel.getS3Path()))) {
+                throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, "S3Path");
+            }
+            if (!Optional.ofNullable(currModel.getRoleArn()).equals(Optional.ofNullable(prevModel.getRoleArn()))) {
+                throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, "RoleArn");
+            }
+            if (!Optional.ofNullable(currModel.getDescription()).equals(Optional.ofNullable(prevModel.getDescription()))) {
+                throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, "Description");
+            }
+        }
     }
 
 

--- a/aws-kendra-faq/src/test/java/software/amazon/kendra/faq/UpdateHandlerTest.java
+++ b/aws-kendra-faq/src/test/java/software/amazon/kendra/faq/UpdateHandlerTest.java
@@ -15,6 +15,7 @@ import software.amazon.awssdk.services.kendra.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.kendra.model.TagResourceRequest;
 import software.amazon.awssdk.services.kendra.model.TagResourceResponse;
 import software.amazon.awssdk.services.kendra.model.UntagResourceRequest;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -25,8 +26,8 @@ import java.time.Duration;
 import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -412,4 +413,155 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeFaq(any(DescribeFaqRequest.class));
     }
 
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException_forIndexId() {
+        final UpdateHandler handler = new UpdateHandler(faqArnBuilder);
+        String indexId = "indexId";
+        String prevIndexId = "prevIndexId";
+        final ResourceModel model = ResourceModel
+                .builder()
+                .indexId(indexId)
+                .build();
+
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .indexId(prevIndexId)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
+    }
+
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException_forName() {
+        final UpdateHandler handler = new UpdateHandler(faqArnBuilder);
+        String name = "name";
+        String prevName = "prevName";
+        String indexId = "indexId";
+        final ResourceModel model = ResourceModel
+                .builder()
+                .name(name)
+                .indexId(indexId)
+                .build();
+
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .indexId(indexId)
+                .name(prevName)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
+    }
+
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException_forS3Path() {
+        final UpdateHandler handler = new UpdateHandler(faqArnBuilder);
+        String indexId = "indexId";
+        String s3Key = "s3Key";
+        String s3Bucket = "s3Bucket";
+        String oldS3Bucket = "oldS3Bucket";
+        S3Path s3Path = S3Path
+                .builder()
+                .key(s3Key)
+                .bucket(s3Bucket)
+                .build();
+        S3Path oldS3Path = S3Path
+                .builder()
+                .key(s3Key)
+                .bucket(oldS3Bucket)
+                .build();
+
+
+        final ResourceModel model = ResourceModel
+                .builder()
+                .s3Path(s3Path)
+                .indexId(indexId)
+                .build();
+
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .indexId(indexId)
+                .s3Path(oldS3Path)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
+    }
+
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException_forDescription() {
+        final UpdateHandler handler = new UpdateHandler(faqArnBuilder);
+        String indexId = "indexId";
+        String description = "description";
+        String oldDescription = "oldDescription";
+
+        final ResourceModel model = ResourceModel
+                .builder()
+                .description(description)
+                .indexId(indexId)
+                .build();
+
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .description(oldDescription)
+                .indexId(indexId)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
+    }
+
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException_forRoleArn() {
+        final UpdateHandler handler = new UpdateHandler(faqArnBuilder);
+        String indexId = "indexId";
+        String roleArn = "roleArn";
+        String oldRoleArn = "oldRoleArn";
+
+        final ResourceModel model = ResourceModel
+                .builder()
+                .roleArn(roleArn)
+                .indexId(indexId)
+                .build();
+
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .roleArn(oldRoleArn)
+                .indexId(indexId)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
+    }
 }

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/UpdateHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/UpdateHandler.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.kendra.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -33,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -77,8 +79,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         final ResourceModel model = request.getDesiredResourceState();
 
-        // TODO: Adjust Progress Chain according to your implementation
-        // https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/blob/master/src/main/java/software/amazon/cloudformation/proxy/CallChain.java
+        verifyNonUpdatableFields(model, request.getPreviousResourceState());
 
         return ProgressEvent.progress(model, callbackContext)
                 // First validate the resource actually exists per the contract requirements
@@ -217,4 +218,20 @@ public class UpdateHandler extends BaseHandlerStd {
         return ProgressEvent.progress(resourceModel, callbackContext);
     }
 
+   /**
+    * Checks the if the create only fields have been updated and throws an exception if it is the case
+    * @param currModel the current resource model
+    * @param prevModel the previous resource model
+    */
+    private void verifyNonUpdatableFields(ResourceModel currModel, ResourceModel prevModel) {
+        if (prevModel != null) {
+            if (!Optional.ofNullable(currModel.getEdition()).equals(Optional.ofNullable(prevModel.getEdition()))) {
+                throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, "Edition");
+            }
+            if (!Optional.ofNullable(currModel.getServerSideEncryptionConfiguration()).equals(
+              Optional.ofNullable(prevModel.getServerSideEncryptionConfiguration()))) {
+                throw new CfnNotUpdatableException(ResourceModel.TYPE_NAME, "ServerSideEncryptionConfiguration");
+            }
+        }
+    }
 }

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/UpdateHandlerTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/UpdateHandlerTest.java
@@ -4,7 +4,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.jupiter.api.AfterEach;
 import software.amazon.awssdk.services.kendra.KendraClient;
 import software.amazon.awssdk.services.kendra.model.ConflictException;
 import software.amazon.awssdk.services.kendra.model.DescribeIndexRequest;
@@ -24,6 +23,7 @@ import software.amazon.awssdk.services.kendra.model.UpdateIndexResponse;
 import software.amazon.awssdk.services.kendra.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
 import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -70,12 +70,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         sdkClient = mock(KendraClient.class);
         proxyClient = MOCK_PROXY(proxy, sdkClient);
-    }
-
-    @AfterEach
-    public void post_execute() {
-        verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -136,6 +130,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(4)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -216,6 +212,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(5)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -245,6 +243,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(2)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -274,6 +274,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         });
         verify(proxyClient.client(), times(2)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -344,6 +346,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(4)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -411,6 +415,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(4)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -489,6 +495,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -538,6 +546,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(3)).describeIndex(any(DescribeIndexRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -587,6 +597,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(3)).describeIndex(any(DescribeIndexRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -616,6 +628,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         });
         verify(proxyClient.client(), times(2)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -637,5 +651,64 @@ public class UpdateHandlerTest extends AbstractTestBase {
             handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
         });
         verify(proxyClient.client(), times(1)).describeIndex(any(DescribeIndexRequest.class));
+        verify(sdkClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(sdkClient);
+    }
+
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException_forEdition() {
+        final UpdateHandler handler = new UpdateHandler(testIndexArnBuilder, testDelay);
+
+        final ResourceModel model = ResourceModel
+                .builder()
+                .edition(IndexEdition.ENTERPRISE_EDITION.toString())
+                .build();
+
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .edition("Invalid")
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
+    }
+
+    @Test
+    public void handleRequest_FailWith_CfnNotUpdatableException_forServerSideEncryptionConfiguration() {
+        final UpdateHandler handler = new UpdateHandler(testIndexArnBuilder, testDelay);
+        final ServerSideEncryptionConfiguration serverSideEncryptionConfiguration = ServerSideEncryptionConfiguration.builder()
+            .kmsKeyId("kmsKeyId")
+            .build();
+
+        final ServerSideEncryptionConfiguration oldServerSideEncryptionConfiguration = ServerSideEncryptionConfiguration.builder()
+            .kmsKeyId("oldKmsKeyId")
+            .build();
+
+        final ResourceModel model = ResourceModel
+                .builder()
+                .edition(IndexEdition.ENTERPRISE_EDITION.toString())
+                .serverSideEncryptionConfiguration(serverSideEncryptionConfiguration)
+                .build();
+
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .edition(IndexEdition.ENTERPRISE_EDITION.toString())
+                .serverSideEncryptionConfiguration(oldServerSideEncryptionConfiguration)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .previousResourceState(prevModel)
+                .build();
+
+        assertThrows(CfnNotUpdatableException.class, () -> {
+            handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
+        });
     }
 }


### PR DESCRIPTION
*Description of changes:*

* Adding validation for create only fields. We now throw CfnNotUpdatableException when there is an attempt to update a create only field.
* This fixes the contract test **contract_update_create_only_property**
