### PR TITLE
adding post execute method to run after each unit test

### DIFF
--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/UpdateHandlerTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/UpdateHandlerTest.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.kendra.KendraClient;
 import software.amazon.awssdk.services.kendra.model.ConflictException;
@@ -76,6 +77,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
         proxyClient = MOCK_PROXY(proxy, awsKendraClient);
     }
 
+    @AfterEach
+    public void post_execute() {
+        verifyNoMoreInteractions(awsKendraClient);
+    }
+
     @Test
     public void handleRequest_SimpleSuccess() {
         final UpdateHandler handler = new UpdateHandler(testDataSourceArnBuilder);
@@ -143,7 +149,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(3)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
 
     }
 
@@ -226,8 +231,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(4)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
-
     }
 
     @Test
@@ -257,7 +260,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -287,7 +289,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
 
     }
 
@@ -318,7 +319,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -348,7 +348,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -424,7 +423,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -497,7 +495,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -583,7 +580,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -635,7 +631,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(2)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test
@@ -688,7 +683,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(2)).describeDataSource(any(DescribeDataSourceRequest.class));
 
         verify(awsKendraClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(awsKendraClient);
     }
 
     @Test

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/UpdateHandlerTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/UpdateHandlerTest.java
@@ -4,6 +4,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.jupiter.api.AfterEach;
 import software.amazon.awssdk.services.kendra.KendraClient;
 import software.amazon.awssdk.services.kendra.model.ConflictException;
 import software.amazon.awssdk.services.kendra.model.DescribeIndexRequest;
@@ -72,6 +73,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
         proxyClient = MOCK_PROXY(proxy, sdkClient);
     }
 
+    @AfterEach
+    public void post_execute() {
+        verifyNoMoreInteractions(sdkClient);
+    }
+
     @Test
     public void handleRequest_SimpleSuccess() {
         final UpdateHandler handler = new UpdateHandler(testIndexArnBuilder, testDelay);
@@ -131,7 +137,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(3)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -206,7 +211,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(4)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -237,7 +241,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -268,7 +271,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -340,7 +342,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -409,7 +410,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -489,7 +489,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -540,7 +539,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(2)).describeIndex(any(DescribeIndexRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -591,7 +589,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(2)).describeIndex(any(DescribeIndexRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -622,7 +619,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         verify(proxyClient.client(), times(1)).describeIndex(any(DescribeIndexRequest.class));
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test
@@ -645,7 +641,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
         });
         verify(proxyClient.client(), times(1)).describeIndex(any(DescribeIndexRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
-        verifyNoMoreInteractions(sdkClient);
     }
 
     @Test


### PR DESCRIPTION
*Description of changes:*
* Adding post_execute method to run after each unit test for update handlers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
