### PR TITLE
Fix error messages

### DIFF
--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/CreateHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/CreateHandler.java
@@ -93,7 +93,7 @@ public class CreateHandler extends BaseHandlerStd {
             createDataSourceResponse = proxyClient.injectCredentialsAndInvokeV2(createDataSourceRequest,
              proxyClient.client()::createDataSource);
         } catch(final ValidationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (final ConflictException e) {
             throw new CfnResourceConflictException(e);
         } catch (final AwsServiceException e) {

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/UpdateHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/UpdateHandler.java
@@ -101,7 +101,7 @@ public class UpdateHandler extends BaseHandlerStd {
         try {
             updateDataSourceResponse = proxyClient.injectCredentialsAndInvokeV2(updateDataSourceRequest, proxyClient.client()::updateDataSource);
         } catch (ValidationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (ResourceNotFoundException e) {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, updateDataSourceRequest.id(), e);
         } catch (ConflictException e) {
@@ -171,7 +171,7 @@ public class UpdateHandler extends BaseHandlerStd {
             try {
                 proxyClient.injectCredentialsAndInvokeV2(tagResourceRequest, proxyClient.client()::tagResource);
             } catch (ValidationException e) {
-                throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+                throw new CfnInvalidRequestException(e.getMessage(), e);
             }
         }
 
@@ -181,7 +181,7 @@ public class UpdateHandler extends BaseHandlerStd {
             try {
                 proxyClient.injectCredentialsAndInvokeV2(untagResourceRequest, proxyClient.client()::untagResource);
             } catch (ValidationException e) {
-                throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+                throw new CfnInvalidRequestException(e.getMessage(), e);
             }
         }
         return ProgressEvent.progress(resourceModel, callbackContext);

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/CreateHandler.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/CreateHandler.java
@@ -110,7 +110,7 @@ public class CreateHandler extends BaseHandlerStd {
         try {
             createFaqResponse = proxyClient.injectCredentialsAndInvokeV2(createFaqRequest, proxyClient.client()::createFaq);
         } catch (ValidationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (ConflictException e) {
             throw new CfnResourceConflictException(e);
         } catch (final AwsServiceException e) {

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/UpdateHandler.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/UpdateHandler.java
@@ -80,7 +80,7 @@ public class UpdateHandler extends BaseHandlerStd {
             try {
                 proxyClient.injectCredentialsAndInvokeV2(tagResourceRequest, proxyClient.client()::tagResource);
             } catch (ValidationException e) {
-                throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+                throw new CfnInvalidRequestException(e.getMessage(), e);
             }
         }
 
@@ -90,7 +90,7 @@ public class UpdateHandler extends BaseHandlerStd {
             try {
                 proxyClient.injectCredentialsAndInvokeV2(untagResourceRequest, proxyClient.client()::untagResource);
             } catch (ValidationException e) {
-                throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+                throw new CfnInvalidRequestException(e.getMessage(), e);
             }
         }
 

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/CreateHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/CreateHandler.java
@@ -135,7 +135,7 @@ public class CreateHandler extends BaseHandlerStd {
         try {
             createIndexResponse = proxyClient.injectCredentialsAndInvokeV2(createIndexRequest, proxyClient.client()::createIndex);
         } catch (ValidationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (ConflictException e) {
             throw new CfnResourceConflictException(e);
         } catch (ServiceQuotaExceededException e) {
@@ -169,7 +169,7 @@ public class CreateHandler extends BaseHandlerStd {
             updateIndexResponse = proxyClient.injectCredentialsAndInvokeV2(updateIndexRequest,
                     proxyClient.client()::updateIndex);
         } catch (ValidationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (ServiceQuotaExceededException e) {
             throw new CfnServiceLimitExceededException(ResourceModel.TYPE_NAME, e.getMessage(), e.getCause());
         } catch (final AwsServiceException e) {

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/UpdateHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/UpdateHandler.java
@@ -114,7 +114,7 @@ public class UpdateHandler extends BaseHandlerStd {
         try {
             return Translator.translateToUpdateRequest(model, prevModel);
         } catch (TranslatorValidationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         }
     }
 
@@ -149,7 +149,7 @@ public class UpdateHandler extends BaseHandlerStd {
         try {
             updateIndexResponse = proxyClient.injectCredentialsAndInvokeV2(updateIndexRequest, proxyClient.client()::updateIndex);
         } catch (ValidationException e) {
-            throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnInvalidRequestException(e.getMessage(), e);
         } catch (ConflictException e) {
             throw new CfnResourceConflictException(e);
         } catch (ServiceQuotaExceededException e) {
@@ -194,7 +194,7 @@ public class UpdateHandler extends BaseHandlerStd {
             try {
                 proxyClient.injectCredentialsAndInvokeV2(tagResourceRequest, proxyClient.client()::tagResource);
             } catch (ValidationException e) {
-                throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+                throw new CfnInvalidRequestException(e.getMessage(), e);
             }
         }
 
@@ -204,7 +204,7 @@ public class UpdateHandler extends BaseHandlerStd {
             try {
                 proxyClient.injectCredentialsAndInvokeV2(untagResourceRequest, proxyClient.client()::untagResource);
             } catch (ValidationException e) {
-                throw new CfnInvalidRequestException(ResourceModel.TYPE_NAME, e);
+                throw new CfnInvalidRequestException(e.getMessage(), e);
             }
         }
         return ProgressEvent.progress(resourceModel, callbackContext);


### PR DESCRIPTION
### Notes
- Fixes error messages for validation exceptions
- Right now, we add the resource type to the error message and it results in a weird error message 
   - e.g.:
```
Invalid request provided: AWS::Kendra::DataSourceAppropriate data source configuration(s) is(are) not provided for data source type SHAREPOINT. Please only provide one configuration of type: SharePointConfiguration. (Service: Kendra, Status Code: 400, Request ID: 40c0bd8b-a21b-4f1c-95b6-2bb03db3c128, Extended Request ID: null)
```
- I've removed the resource type name from the message completely. I dont think we need the resource type in the message at all - the error message will be next to the resource that resulted in the error so the context makes it clear which resource had issues.

### Testing
- ```mvn clean verify --no-transfer-progress```
- Manually created an invalid stack and confirmed the error message went from:
```
Invalid request provided: AWS::Kendra::DataSourceAppropriate data source configuration(s) is(are) not provided for data source type SHAREPOINT. Please only provide one configuration of type: SharePointConfiguration. (Service: Kendra, Status Code: 400, Request ID: 40c0bd8b-a21b-4f1c-95b6-2bb03db3c128, Extended Request ID: null)
```
to:
```
Invalid request provided: Appropriate data source configuration(s) is(are) not provided for data source type SHAREPOINT. Please only provide one configuration of type: SharePointConfiguration. (Service: Kendra, Status Code: 400, Request ID: e9361bfd-b73c-41f9-a8a6-71669eabe079, Extended Request ID: null)
```