### PR TITLE
Use previous state for determining tag changes

### DIFF
--- a/aws-kendra-faq/src/test/java/software/amazon/kendra/faq/UpdateHandlerTest.java
+++ b/aws-kendra-faq/src/test/java/software/amazon/kendra/faq/UpdateHandlerTest.java
@@ -129,8 +129,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyClient.client(), times(2))
-                .listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).describeFaq(any(DescribeFaqRequest.class));
     }
 
@@ -168,7 +167,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .build();
 
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build())
                 .thenReturn(ListTagsForResourceResponse
                         .builder()
                         .tags(software.amazon.awssdk.services.kendra.model.Tag
@@ -219,8 +217,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyClient.client(), times(2))
-                .listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1))
                 .tagResource(any(TagResourceRequest.class));
         verify(proxyClient.client(), times(1)).describeFaq(any(DescribeFaqRequest.class));
@@ -232,8 +229,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         String faqId = "faqId";
         String indexId = "indexId";
-        String key = "key";
-        String value = "value";
         String name = "name";
         String description = "description";
         String roleArn = "roleArn";
@@ -254,19 +249,25 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .s3Path(s3Path)
                 .build();
 
+        String key = "key";
+        String value = "value";
+        ResourceModel prevModel = ResourceModel
+                .builder()
+                .id(faqId)
+                .indexId(indexId)
+                .name(name)
+                .description(description)
+                .roleArn(roleArn)
+                .s3Path(s3Path)
+                .tags(Arrays.asList(Tag.builder().key(key).value(value).build()))
+                .build();
+
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(resourceModel)
+                .previousResourceState(prevModel)
                 .build();
 
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse
-                        .builder()
-                        .tags(software.amazon.awssdk.services.kendra.model.Tag
-                                .builder()
-                                .key(key)
-                                .value(value)
-                                .build())
-                        .build())
                 .thenReturn(ListTagsForResourceResponse.builder().build());
 
         when(proxyClient.client().describeFaq(any(DescribeFaqRequest.class)))
@@ -306,8 +307,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyClient.client(), times(2))
-                .listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1))
                 .untagResource(any(UntagResourceRequest.class));
         verify(proxyClient.client(), times(1)).describeFaq(any(DescribeFaqRequest.class));
@@ -341,22 +341,25 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .s3Path(s3Path)
                 .tags(Arrays.asList(Tag.builder().key(tagKeyToAdd).value(tagValueToAdd).build()))
                 .build();
+        String tagKeyToRemove = "keyToRemove";
+        String tagValueToRemove = "valueToRemove";
+        ResourceModel prevModel = ResourceModel
+                .builder()
+                .id(faqId)
+                .indexId(indexId)
+                .name(name)
+                .description(description)
+                .roleArn(roleArn)
+                .s3Path(s3Path)
+                .tags(Arrays.asList(Tag.builder().key(tagKeyToRemove).value(tagValueToRemove).build()))
+                .build();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(resourceModel)
+                .previousResourceState(prevModel)
                 .build();
 
-        String tagKeyToRemove = "keyToRemove";
-        String tagValueToRemove = "valueToRemove";
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse
-                        .builder()
-                        .tags(software.amazon.awssdk.services.kendra.model.Tag
-                                .builder()
-                                .key(tagKeyToRemove)
-                                .value(tagValueToRemove)
-                                .build())
-                        .build())
                 .thenReturn(ListTagsForResourceResponse
                         .builder()
                         .tags(software.amazon.awssdk.services.kendra.model.Tag
@@ -404,8 +407,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
-        verify(proxyClient.client(), times(2))
-                .listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1))
                 .untagResource(any(UntagResourceRequest.class));
         verify(proxyClient.client(), times(1))

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/UpdateHandlerTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/UpdateHandlerTest.java
@@ -113,7 +113,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .builder()
                         .tags((java.util.Collection<software.amazon.awssdk.services.kendra.model.Tag>) null)
                         .build());
-
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
@@ -135,7 +134,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(3)).describeIndex(any(DescribeIndexRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
     }
 
@@ -209,7 +208,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(4)).describeIndex(any(DescribeIndexRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
     }
 
@@ -309,7 +308,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .build());
 
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build())
                 .thenReturn(ListTagsForResourceResponse
                         .builder()
                         .tags(Arrays.asList(software.amazon.awssdk.services.kendra.model.Tag
@@ -339,7 +337,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(3)).describeIndex(any(DescribeIndexRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
     }
@@ -360,8 +358,17 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .edition(indexEdition)
                 .build();
 
+        String key = "key";
+        String value = "value";
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .tags(Arrays.asList(Tag.builder().key(key).value(value).build()))
+                .edition(indexEdition)
+                .build();
+
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .previousResourceState(prevModel)
                 .build();
 
         when(proxyClient.client().updateIndex(any(UpdateIndexRequest.class)))
@@ -375,14 +382,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .status(IndexStatus.ACTIVE.toString())
                         .build());
 
-        String key = "key";
-        String value = "value";
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse
-                        .builder()
-                        .tags(Arrays.asList(software.amazon.awssdk.services.kendra.model.Tag
-                                .builder().key(key).value(value).build()))
-                        .build())
                 .thenReturn(ListTagsForResourceResponse.builder().build());
         when(proxyClient.client().untagResource(any(UntagResourceRequest.class)))
                 .thenReturn(UntagResourceResponse.builder().build());
@@ -407,7 +407,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(3)).describeIndex(any(DescribeIndexRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
     }
@@ -432,8 +432,17 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .edition(indexEdition)
                 .build();
 
+        String keyRemove = "keyRemove";
+        String valueRemove = "valueRemove";
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .edition(indexEdition)
+                .tags(Arrays.asList(Tag.builder().key(keyRemove).value(valueRemove).build()))
+                .build();
+
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .previousResourceState(prevModel)
                 .build();
 
         when(proxyClient.client().updateIndex(any(UpdateIndexRequest.class)))
@@ -443,18 +452,11 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .id(id)
                         .name(name)
                         .roleArn(roleArn)
-                        .edition(indexEdition.toString())
+                        .edition(indexEdition)
                         .status(IndexStatus.ACTIVE.toString())
                         .build());
 
-        String keyRemove = "keyRemove";
-        String valueRemove = "valueRemove";
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse
-                        .builder()
-                        .tags(Arrays.asList(software.amazon.awssdk.services.kendra.model.Tag
-                                .builder().key(keyRemove).value(valueRemove).build()))
-                        .build())
                 .thenReturn(ListTagsForResourceResponse
                         .builder()
                         .tags(Arrays.asList(software.amazon.awssdk.services.kendra.model.Tag
@@ -473,7 +475,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .builder()
                 .id(id)
                 .arn(testIndexArnBuilder.build(request))
-                .edition(indexEdition.toString())
+                .edition(indexEdition)
                 .roleArn(roleArn)
                 .name(name)
                 .tags(tagsToAdd)
@@ -485,7 +487,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         verify(proxyClient.client(), times(1)).updateIndex(any(UpdateIndexRequest.class));
         verify(proxyClient.client(), times(3)).describeIndex(any(DescribeIndexRequest.class));
-        verify(proxyClient.client(), times(2)).listTagsForResource(any(ListTagsForResourceRequest.class));
+        verify(proxyClient.client(), times(1)).listTagsForResource(any(ListTagsForResourceRequest.class));
         verify(proxyClient.client(), times(1)).tagResource(any(TagResourceRequest.class));
         verify(proxyClient.client(), times(1)).untagResource(any(UntagResourceRequest.class));
         verify(sdkClient, atLeastOnce()).serviceName();
@@ -522,9 +524,6 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .status(IndexStatus.ACTIVE.toString())
                         .build());
 
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse.builder().build());
-
         when(proxyClient.client().tagResource(any(TagResourceRequest.class)))
                 .thenThrow(ValidationException.builder().build());
 
@@ -557,6 +556,12 @@ public class UpdateHandlerTest extends AbstractTestBase {
                 .edition(indexEdition)
                 .build();
 
+        final ResourceModel prevModel = ResourceModel
+                .builder()
+                .edition(indexEdition)
+                .tags(Arrays.asList(Tag.builder().key("key").value("value").build()))
+                .build();
+
         when(proxyClient.client().updateIndex(any(UpdateIndexRequest.class)))
                 .thenReturn(UpdateIndexResponse.builder().build());
         when(proxyClient.client().describeIndex(any(DescribeIndexRequest.class)))
@@ -568,18 +573,12 @@ public class UpdateHandlerTest extends AbstractTestBase {
                         .status(IndexStatus.ACTIVE.toString())
                         .build());
 
-        when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(ListTagsForResourceResponse
-                        .builder()
-                        .tags(Arrays.asList(software.amazon.awssdk.services.kendra.model.Tag
-                                .builder().key("key").value("value").build()))
-                        .build());
-
         when(proxyClient.client().untagResource(any(UntagResourceRequest.class)))
                 .thenThrow(ValidationException.builder().build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .previousResourceState(prevModel)
                 .build();
 
         assertThrows(CfnInvalidRequestException.class, () -> {


### PR DESCRIPTION
### Notes
- Currently, we call ```ListTagsForResource``` for determining which tags to add/remove. As discussed with CloudFormation previously, we should not do this - that is, we shouldn't query the live state of the resource. The source of truth comes from the CloudFormation templates. Instead, we should use the previous state which comes from the previous CloudFormation template. Made the changes here for this.

### Testing
- Updated unit tests
- Manually tested an index