### PR TITLE
Revert "Use client request token provided by CloudFormation (#52)"

### DIFF
--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/CreateHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/CreateHandler.java
@@ -87,7 +87,7 @@ public class CreateHandler extends BaseHandlerStd {
                         // If your service API throws 'ResourceAlreadyExistsException' for create requests then CreateHandler can return just proxy.initiate construction
                         // STEP 2.0 [initialize a proxy context]
                         proxy.initiate("AWS-Kendra-Index::Create", proxyClient, request.getDesiredResourceState(), callbackContext)
-                                .translateToServiceRequest((resourceModel) -> Translator.translateToCreateRequest(resourceModel, request.getClientRequestToken()))
+                                .translateToServiceRequest(Translator::translateToCreateRequest)
                                 .makeServiceCall(this::createIndex)
                                 .done(this::setId)
                 )

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
@@ -39,14 +39,13 @@ import java.util.stream.Stream;
 
 public class Translator {
 
-  static CreateIndexRequest translateToCreateRequest(final ResourceModel model, final String clientRequestToken) {
+  static CreateIndexRequest translateToCreateRequest(final ResourceModel model) {
     final CreateIndexRequest.Builder builder = CreateIndexRequest
             .builder()
             .name(model.getName())
             .roleArn(model.getRoleArn())
             .description(model.getDescription())
-            .edition(model.getEdition())
-            .clientToken(clientRequestToken);
+            .edition(model.getEdition());
     builder.tags(ListConverter.toSdk(model.getTags(), x -> Tag.builder().key(x.getKey()).value(x.getValue()).build()));
     if (model.getServerSideEncryptionConfiguration() != null
             && (model.getServerSideEncryptionConfiguration().getKmsKeyId() != null)) {

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/TranslatorTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/TranslatorTest.java
@@ -241,7 +241,7 @@ class TranslatorTest {
     }
 
     @Test
-    void testTranslateToCreateRequestNameRoleDescriptionClientTokenEdition() {
+    void testTranslateToCreateRequestNameRoleDescriptionEdition() {
         String name = "name";
         String description = "description";
         String roleArn = "roleArn";
@@ -253,13 +253,11 @@ class TranslatorTest {
                 .roleArn(roleArn)
                 .edition(edition)
                 .build();
-        String clientRequestToken = "clientRequestToken";
-        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel, clientRequestToken);
+        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel);
         assertThat(actualCreateIndexRequest.description()).isEqualTo(description);
         assertThat(actualCreateIndexRequest.name()).isEqualTo(name);
         assertThat(actualCreateIndexRequest.editionAsString()).isEqualTo(edition);
         assertThat(actualCreateIndexRequest.roleArn()).isEqualTo(roleArn);
-        assertThat(actualCreateIndexRequest.clientToken()).isEqualTo(clientRequestToken);
     }
 
     @Test
@@ -271,7 +269,7 @@ class TranslatorTest {
                 .builder()
                 .tags(Arrays.asList(tag))
                 .build();
-        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel, null);
+        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel);
         assertThat(actualCreateIndexRequest.tags().size()).isEqualTo(1);
         assertThat(actualCreateIndexRequest.tags().get(0).key()).isEqualTo(key);
         assertThat(actualCreateIndexRequest.tags().get(0).value()).isEqualTo(value);
@@ -288,7 +286,7 @@ class TranslatorTest {
                 .builder()
                 .serverSideEncryptionConfiguration(serverSideEncryptionConfiguration)
                 .build();
-        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel, null);
+        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel);
         assertThat(actualCreateIndexRequest.serverSideEncryptionConfiguration().kmsKeyId()).isEqualTo(kmsKeyId);
     }
 
@@ -301,7 +299,7 @@ class TranslatorTest {
                 .builder()
                 .serverSideEncryptionConfiguration(serverSideEncryptionConfiguration)
                 .build();
-        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel, null);
+        CreateIndexRequest actualCreateIndexRequest = Translator.translateToCreateRequest(resourceModel);
         assertThat(actualCreateIndexRequest.serverSideEncryptionConfiguration()).isNull();
     }
 


### PR DESCRIPTION
### Notes
- Reverting changes related to idempotency token as they're causing issues with the contract tests

### Testing
- Re-ran contract tests