### PR TITLE
Fix CfnGeneralServiceException error message

### DIFF
--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ApiName.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ApiName.java
@@ -1,0 +1,9 @@
+package software.amazon.kendra.datasource;
+
+public class ApiName {
+    static final String CREATE_DATASOURCE = "CreateDataSource";
+    static final String UPDATE_DATASOURCE = "UpdateDataSource";
+    static final String DESCRIBE_DATASOURCE = "DescribeDataSource";
+    static final String DELETE_DATASOURCE = "DeleteDataSource";
+    static final String LIST_TAGS_FOR_RESOURCE = "ListTagsForResource";
+}

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/CreateHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/CreateHandler.java
@@ -22,6 +22,8 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static software.amazon.kendra.datasource.ApiName.CREATE_DATASOURCE;
+
 public class CreateHandler extends BaseHandlerStd {
 
     protected static final BiFunction<ResourceModel, ProxyClient<KendraClient>, ResourceModel> EMPTY_CALL =
@@ -103,7 +105,7 @@ public class CreateHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(CREATE_DATASOURCE, e);
         }
 
         logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/DeleteHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/DeleteHandler.java
@@ -20,6 +20,8 @@ import software.amazon.cloudformation.proxy.delay.Constant;
 
 import java.time.Duration;
 
+import static software.amazon.kendra.datasource.ApiName.DELETE_DATASOURCE;
+
 public class DeleteHandler extends BaseHandlerStd {
 
     private static final Constant STABILIZATION_DELAY = Constant.of()
@@ -110,7 +112,7 @@ public class DeleteHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(DELETE_DATASOURCE, e);
         }
 
         logger.log(String.format("%s successfully deleted.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ReadHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ReadHandler.java
@@ -16,6 +16,9 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static software.amazon.kendra.datasource.ApiName.DESCRIBE_DATASOURCE;
+import static software.amazon.kendra.datasource.ApiName.LIST_TAGS_FOR_RESOURCE;
+
 public class ReadHandler extends BaseHandlerStd {
 
     private Logger logger;
@@ -48,7 +51,7 @@ public class ReadHandler extends BaseHandlerStd {
         } catch (ResourceNotFoundException e) {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, describeDataSourceRequest.id(), e);
         } catch (final AwsServiceException e) {
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(DESCRIBE_DATASOURCE, e);
         }
         // STEP 4 [Add List Tags for DataSource]
         String dataSourceArn = dataSourceArnBuilder.build(request);
@@ -58,7 +61,7 @@ public class ReadHandler extends BaseHandlerStd {
             listTagsForResourceResponse = proxyClient.injectCredentialsAndInvokeV2(listTagsForResourceRequest,
                     proxyClient.client()::listTagsForResource);
         } catch (ResourceInUseException e) {
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(LIST_TAGS_FOR_RESOURCE, e);
         }
         return constructResourceModelFromResponse(describeDataSourceResponse, listTagsForResourceResponse, dataSourceArn);
     }

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/UpdateHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/UpdateHandler.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static software.amazon.kendra.datasource.ApiName.UPDATE_DATASOURCE;
+
 public class UpdateHandler extends BaseHandlerStd {
 
     private Logger logger;
@@ -111,7 +113,7 @@ public class UpdateHandler extends BaseHandlerStd {
             * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
             * to more specific error codes
             */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(UPDATE_DATASOURCE, e);
         }
 
         logger.log(String.format("%s has successfully been updated.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/ApiName.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/ApiName.java
@@ -1,0 +1,8 @@
+package software.amazon.kendra.faq;
+
+public class ApiName {
+    static final String CREATE_FAQ = "CreateFaq";
+    static final String DESCRIBE_FAQ = "DescribeFaq";
+    static final String DELETE_FAQ = "DeleteFaq";
+    static final String LIST_TAGS_FOR_RESOURCE = "ListTagsForResource";
+}

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/CreateHandler.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/CreateHandler.java
@@ -22,6 +22,8 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static software.amazon.kendra.faq.ApiName.CREATE_FAQ;
+
 public class CreateHandler extends BaseHandlerStd {
     protected static final BiFunction<ResourceModel, ProxyClient<KendraClient>, ResourceModel> EMPTY_CALL =
             (model, proxyClient) -> model;
@@ -120,7 +122,7 @@ public class CreateHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(CREATE_FAQ, e);
         }
 
         logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/DeleteHandler.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/DeleteHandler.java
@@ -16,6 +16,8 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static software.amazon.kendra.faq.ApiName.DELETE_FAQ;
+
 public class DeleteHandler extends BaseHandlerStd {
     private Logger logger;
 
@@ -80,7 +82,7 @@ public class DeleteHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(DELETE_FAQ, e);
         }
 
         logger.log(String.format("%s successfully deleted.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/ReadHandler.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/ReadHandler.java
@@ -17,6 +17,9 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static software.amazon.kendra.faq.ApiName.DESCRIBE_FAQ;
+import static software.amazon.kendra.faq.ApiName.LIST_TAGS_FOR_RESOURCE;
+
 public class ReadHandler extends BaseHandlerStd {
     private Logger logger;
     private FaqArnBuilder faqArnBuilder;
@@ -53,7 +56,7 @@ public class ReadHandler extends BaseHandlerStd {
             listTagsForResourceResponse = proxyClient.injectCredentialsAndInvokeV2(listTagsForResourceRequest,
                     proxyClient.client()::listTagsForResource);
         } catch (ResourceInUseException e) {
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(LIST_TAGS_FOR_RESOURCE, e);
         }
         return constructResourceModelFromResponse(describeFaqResponse, listTagsForResourceResponse, faqArn);
     }
@@ -81,7 +84,7 @@ public class ReadHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e); // e.g. https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/commit/2077c92299aeb9a68ae8f4418b5e932b12a8b186#diff-5761e3a9f732dc1ef84103dc4bc93399R56-R63
+            throw new CfnGeneralServiceException(DESCRIBE_FAQ, e); // e.g. https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/commit/2077c92299aeb9a68ae8f4418b5e932b12a8b186#diff-5761e3a9f732dc1ef84103dc4bc93399R56-R63
         }
 
         logger.log(String.format("%s has successfully been read.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/ApiName.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/ApiName.java
@@ -1,0 +1,9 @@
+package software.amazon.kendra.index;
+
+public class ApiName {
+    static final String CREATE_INDEX = "CreateIndex";
+    static final String UPDATE_INDEX = "UpdateIndex";
+    static final String DELETE_INDEX = "DeleteIndex";
+    static final String DESCRIBE_INDEX = "DescribeIndex";
+    static final String LIST_TAGS_FOR_RESOURCE = "ListTagsForResource";
+}

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/CreateHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/CreateHandler.java
@@ -29,6 +29,9 @@ import java.time.Duration;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import static software.amazon.kendra.index.ApiName.CREATE_INDEX;
+import static software.amazon.kendra.index.ApiName.UPDATE_INDEX;
+
 public class CreateHandler extends BaseHandlerStd {
 
     private static final Constant STABILIZATION_DELAY = Constant.of()
@@ -147,7 +150,7 @@ public class CreateHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnGeneralServiceException(CREATE_INDEX, e);
         }
 
         logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
@@ -179,7 +182,7 @@ public class CreateHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(UPDATE_INDEX, e);
         }
 
         logger.log(String.format("%s successfully updated.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/DeleteHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/DeleteHandler.java
@@ -20,6 +20,8 @@ import software.amazon.cloudformation.proxy.delay.Constant;
 
 import java.time.Duration;
 
+import static software.amazon.kendra.index.ApiName.DELETE_INDEX;
+
 public class DeleteHandler extends BaseHandlerStd {
 
     private static final Constant STABILIZATION_DELAY = Constant.of()
@@ -116,7 +118,7 @@ public class DeleteHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnGeneralServiceException(DELETE_INDEX, e);
         }
 
         logger.log(String.format("%s successfully deleted.", ResourceModel.TYPE_NAME));

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/ReadHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/ReadHandler.java
@@ -16,6 +16,9 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import static software.amazon.kendra.index.ApiName.DESCRIBE_INDEX;
+import static software.amazon.kendra.index.ApiName.LIST_TAGS_FOR_RESOURCE;
+
 public class ReadHandler extends BaseHandlerStd {
 
     private Logger logger;
@@ -57,7 +60,7 @@ public class ReadHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME + e.getMessage(), e); // e.g. https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/commit/2077c92299aeb9a68ae8f4418b5e932b12a8b186#diff-5761e3a9f732dc1ef84103dc4bc93399R56-R63
+            throw new CfnGeneralServiceException(DESCRIBE_INDEX, e); // e.g. https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-logs/commit/2077c92299aeb9a68ae8f4418b5e932b12a8b186#diff-5761e3a9f732dc1ef84103dc4bc93399R56-R63
         }
 
         String indexArn = indexArnBuilder.build(request);
@@ -67,7 +70,7 @@ public class ReadHandler extends BaseHandlerStd {
             listTagsForResourceResponse = proxyClient.injectCredentialsAndInvokeV2(listTagsForResourceRequest,
                     proxyClient.client()::listTagsForResource);
         } catch (ResourceInUseException e) {
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+            throw new CfnGeneralServiceException(LIST_TAGS_FOR_RESOURCE, e);
         }
 
         return constructResourceModelFromResponse(describeIndexResponse, listTagsForResourceResponse, indexArn);

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/UpdateHandler.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/UpdateHandler.java
@@ -34,6 +34,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static software.amazon.kendra.index.ApiName.UPDATE_INDEX;
+
 public class UpdateHandler extends BaseHandlerStd {
 
     private static final Constant STABILIZATION_DELAY = Constant.of()
@@ -158,7 +160,7 @@ public class UpdateHandler extends BaseHandlerStd {
              * Each BaseHandlerException maps to a specific error code, and you should map service exceptions as closely as possible
              * to more specific error codes
              */
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME + e.getMessage(), e);
+            throw new CfnGeneralServiceException(UPDATE_INDEX, e);
         }
 
         logger.log(String.format("%s has successfully been updated.", ResourceModel.TYPE_NAME));


### PR DESCRIPTION
### Notes
- Fixes CfnGeneralServiceException messages. Right now we're inconsistent with what we provide to CfnGeneralServiceException. Either way, the exceptions expects which operation caused the failure. 
- The CfnGeneralServiceException expects operation name as an argument:
```
    public CfnGeneralServiceException(String operation, Throwable cause) {
        super(String.format(ERROR_CODE.getMessage(), operation), cause, ERROR_CODE);
    }
...

  GeneralServiceException("Error occurred during operation '%s'."),

...
```

### Testing
- Unit tests