### PR TITLE
Create definitions for all property types

### DIFF
--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -758,40 +758,6 @@
       "required": [
         "DocumentDataFieldName"
       ]
-    }
-  },
-  "properties": {
-    "Id": {
-      "description": "ID of data source",
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 100,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
-    },
-    "Arn": {
-      "type": "string"
-    },
-    "Name": {
-      "description": "Name of data source",
-      "type": "string",
-      "minLength": 1,
-      "maxLength": 1000,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
-    },
-    "IndexId": {
-      "$ref": "#/definitions/IndexId"
-    },
-    "Type": {
-      "description": "Data source type",
-      "type": "string",
-      "enum": [
-        "S3",
-        "SHAREPOINT",
-        "SALESFORCE",
-        "ONEDRIVE",
-        "SERVICENOW",
-        "DATABASE"
-      ]
     },
     "DataSourceConfiguration": {
       "type": "object",
@@ -816,6 +782,25 @@
         }
       }
     },
+    "Name": {
+      "description": "Name of data source",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
+    },
+    "Type": {
+      "description": "Data source type",
+      "type": "string",
+      "enum": [
+        "S3",
+        "SHAREPOINT",
+        "SALESFORCE",
+        "ONEDRIVE",
+        "SERVICENOW",
+        "DATABASE"
+      ]
+    },
     "Description": {
       "description": "Description of data source",
       "type": "string",
@@ -823,16 +808,55 @@
       "maxLength": 1000,
       "pattern": "^\\P{C}*$"
     },
-    "Schedule": {
-      "description": "Schedule",
-      "type": "string"
-    },
     "RoleArn": {
       "description": "Role ARN",
       "type": "string",
       "minLength": 1,
       "maxLength": 1284,
       "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
+    },
+    "Schedule": {
+      "description": "Schedule",
+      "type": "string"
+    },
+    "Id": {
+      "description": "ID of data source",
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100,
+      "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
+    },
+    "Arn": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "Id": {
+      "$ref": "#/definitions/Id"
+    },
+    "Arn": {
+      "$ref": "#/definitions/Arn"
+    },
+    "Name": {
+      "$ref": "#/definitions/Name"
+    },
+    "IndexId": {
+      "$ref": "#/definitions/IndexId"
+    },
+    "Type": {
+      "$ref": "#/definitions/Type"
+    },
+    "DataSourceConfiguration": {
+      "$ref": "#/definitions/DataSourceConfiguration"
+    },
+    "Description": {
+      "$ref": "#/definitions/Description"
+    },
+    "Schedule": {
+      "$ref": "#/definitions/Schedule"
+    },
+    "RoleArn": {
+      "$ref": "#/definitions/RoleArn"
     },
     "Tags": {
       "description": "Tags for labeling the data source",

--- a/aws-kendra-faq/aws-kendra-faq.json
+++ b/aws-kendra-faq/aws-kendra-faq.json
@@ -85,15 +85,18 @@
       "minLength": 1,
       "maxLength": 1284,
       "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
-    }
-  },
-  "properties": {
+    },
     "Id": {
       "description": "Unique ID of the FAQ",
       "type": "string",
       "minLength": 1,
       "maxLength": 100,
       "pattern": "[a-zA-Z0-9][a-zA-Z0-9_-]*"
+    }
+  },
+  "properties": {
+    "Id": {
+      "$ref": "#/definitions/Id"
     },
     "IndexId": {
       "description": "Index ID",

--- a/aws-kendra-index/aws-kendra-index.json
+++ b/aws-kendra-index/aws-kendra-index.json
@@ -196,30 +196,14 @@
         "StorageCapacityUnits",
         "QueryCapacityUnits"
       ]
-    }
-  },
-  "properties": {
-    "Id": {
-      "description": "Unique ID of index",
+    },
+    "Edition": {
+      "description": "Edition of index",
       "type": "string",
-      "minLength": 36,
-      "maxLength": 36,
-      "pattern": "[a-zA-Z0-9][a-zA-Z0-9-]*"
-    },
-    "Arn": {
-      "type": "string"
-    },
-    "Description": {
-      "description": "A description for the index",
-      "$ref": "#/definitions/Description"
-    },
-    "ServerSideEncryptionConfiguration": {
-      "description": "Server side encryption configuration",
-      "$ref": "#/definitions/ServerSideEncryptionConfiguration"
-    },
-    "Tags": {
-      "description": "Tags for labeling the index",
-      "$ref": "#/definitions/TagList"
+      "enum": [
+        "DEVELOPER_EDITION",
+        "ENTERPRISE_EDITION"
+      ]
     },
     "Name": {
       "description": "Name of index",
@@ -235,13 +219,44 @@
       "maxLength": 1284,
       "pattern": "arn:[a-z0-9-\\.]{1,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[a-z0-9-\\.]{0,63}:[^/].{0,1023}"
     },
-    "Edition": {
-      "description": "Edition of index",
+    "Id": {
+      "description": "Unique ID of index",
       "type": "string",
-      "enum": [
-        "DEVELOPER_EDITION",
-        "ENTERPRISE_EDITION"
-      ]
+      "minLength": 36,
+      "maxLength": 36,
+      "pattern": "[a-zA-Z0-9][a-zA-Z0-9-]*"
+    },
+    "Arn": {
+      "type": "string"
+    }
+  },
+  "properties": {
+    "Id": {
+      "$ref": "#/definitions/Id"
+    },
+    "Arn": {
+      "$ref": "#/definitions/Arn"
+    },
+    "Description": {
+      "description": "A description for the index",
+      "$ref": "#/definitions/Description"
+    },
+    "ServerSideEncryptionConfiguration": {
+      "description": "Server side encryption configuration",
+      "$ref": "#/definitions/ServerSideEncryptionConfiguration"
+    },
+    "Tags": {
+      "description": "Tags for labeling the index",
+      "$ref": "#/definitions/TagList"
+    },
+    "Name": {
+      "$ref": "#/definitions/Name"
+    },
+    "RoleArn": {
+      "$ref": "#/definitions/RoleArn"
+    },
+    "Edition": {
+      "$ref": "#/definitions/Edition"
     },
     "DocumentMetadataConfigurations": {
       "description": "Document metadata configurations",


### PR DESCRIPTION
### Notes
- Creating definitions for all property types
- There were issues generating documentation for sub-structures that were not defined in the ```definitions``` section

### Testing
- Ran unit tests
- Re-generated documentation