### PR TITLE
Revert "Dont use null equivalent for Description (#64)"

### DIFF
--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
@@ -120,7 +120,7 @@ public class Translator {
    * @return awsRequest the aws service request to modify a resource
    */
   static UpdateDataSourceRequest translateToUpdateRequest(final ResourceModel model) {
-    // Removing this line until the SDK has a min of 0 String description = model.getDescription() == null ? "" : model.getDescription();
+    String description = model.getDescription() == null ? "" : model.getDescription();
     String name = model.getName() == null ? "" : model.getName();
     String roleArn = model.getRoleArn() == null ? "" : model.getRoleArn();
     String schedule = model.getSchedule() == null ? "" : model.getSchedule();
@@ -132,7 +132,7 @@ public class Translator {
       .indexId(model.getIndexId())
       .roleArn(roleArn)
       .name(name)
-      .description(model.getDescription())
+      .description(description)
       .configuration(dataSourceConfiguration)
       .schedule(schedule)
       .build();

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
@@ -145,7 +145,7 @@ public class Translator {
   static UpdateIndexRequest translateToUpdateRequest(final ResourceModel currModel,
                                                      final ResourceModel prevModel) throws TranslatorValidationException {
     // Null equivalents for partial updates.
-    // Removing this line until the SDK has min of 0 String description = currModel.getDescription() == null ? "" : currModel.getDescription();
+    String description = currModel.getDescription() == null ? "" : currModel.getDescription();
     String name = currModel.getName() == null ? "" : currModel.getName();
     String roleArn = currModel.getRoleArn() == null ? "" : currModel.getRoleArn();
     // Handle null previous resource model
@@ -156,7 +156,7 @@ public class Translator {
             .id(currModel.getId())
             .roleArn(roleArn)
             .name(name)
-            .description(currModel.getDescription())
+            .description(description)
             .documentMetadataConfigurationUpdates(
                     translateToSdkDocumentMetadataConfigurationList(
                             currModel.getDocumentMetadataConfigurations(),

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/TranslatorTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/TranslatorTest.java
@@ -477,7 +477,7 @@ class TranslatorTest {
                 .id(id)
                 .build();
         UpdateIndexRequest updateIndexRequest = Translator.translateToUpdateRequest(resourceModel, ResourceModel.builder().build());
-        assertThat(updateIndexRequest.description()).isNull();
+        assertThat(updateIndexRequest.description()).isEqualTo("");
         assertThat(updateIndexRequest.name()).isEqualTo("");
         assertThat(updateIndexRequest.roleArn()).isEqualTo("");
         assertThat(updateIndexRequest.documentMetadataConfigurationUpdates()).isEmpty();


### PR DESCRIPTION
### Notes
- Reverting the previous change where we removed providing the null equivalent String for `Description`.
   - Now that the SDK/Kendra service supports descriptions of length 0, we can provide the empty String 
   - Previously, the min length was 1 and so providing the empty String would have caused a 400 when calling the Kendra service, but the min has been fixed.

### Testing
- Unit tests