### PR TITLE
Add CRUD Cloudformation support for custom_datasource

### DIFF
--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -834,7 +834,8 @@
         "SALESFORCE",
         "ONEDRIVE",
         "SERVICENOW",
-        "DATABASE"
+        "DATABASE",
+        "CUSTOM"
       ]
     },
     "Description": {
@@ -902,9 +903,7 @@
   "required": [
     "Name",
     "IndexId",
-    "Type",
-    "DataSourceConfiguration",
-    "RoleArn"
+    "Type"
   ],
   "handlers": {
     "create": {

--- a/aws-kendra-datasource/pom.xml
+++ b/aws-kendra-datasource/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kendra</artifactId>
-            <version>2.13.66</version>
+            <version>2.15.12</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
@@ -120,23 +120,21 @@ public class Translator {
    * @return awsRequest the aws service request to modify a resource
    */
   static UpdateDataSourceRequest translateToUpdateRequest(final ResourceModel model) {
-    String description = model.getDescription() == null ? "" : model.getDescription();
-    String name = model.getName() == null ? "" : model.getName();
-    String roleArn = model.getRoleArn() == null ? "" : model.getRoleArn();
-    String schedule = model.getSchedule() == null ? "" : model.getSchedule();
-    software.amazon.awssdk.services.kendra.model.DataSourceConfiguration dataSourceConfiguration = model.getDataSourceConfiguration() == null ?
-      software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder().build()
-      : toSdkDataSourceConfiguration(model.getDataSourceConfiguration());
-    final UpdateDataSourceRequest updateDataSourceRequest = UpdateDataSourceRequest.builder()
-      .id(model.getId())
-      .indexId(model.getIndexId())
-      .roleArn(roleArn)
-      .name(name)
-      .description(description)
-      .configuration(dataSourceConfiguration)
-      .schedule(schedule)
-      .build();
-    return updateDataSourceRequest;
+      String description = model.getDescription();
+      String name =  model.getName();
+      String roleArn =  model.getRoleArn();
+      String schedule =  model.getSchedule();
+      software.amazon.awssdk.services.kendra.model.DataSourceConfiguration dataSourceConfiguration = toSdkDataSourceConfiguration(model.getDataSourceConfiguration());
+      final UpdateDataSourceRequest updateDataSourceRequest = UpdateDataSourceRequest.builder()
+          .id(model.getId())
+          .indexId(model.getIndexId())
+          .roleArn(roleArn)
+          .name(name)
+          .description(description)
+          .configuration(dataSourceConfiguration)
+          .schedule(schedule)
+          .build();
+      return updateDataSourceRequest;
   }
 
   /**

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/TranslatorTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/TranslatorTest.java
@@ -91,6 +91,20 @@ public class TranslatorTest {
     }
 
     @Test
+    void testTranslateToCreateRequest_WithCustomDataSource() {
+        String indexId = "indexId";
+        ResourceModel resourceModel = ResourceModel
+            .builder()
+            .indexId(indexId)
+            .type("CUSTOM")
+            .description("description")
+            .build();
+        CreateDataSourceRequest createDataSourceRequest = Translator.translateToCreateRequest(resourceModel);
+        assertThat(createDataSourceRequest.indexId()).isEqualTo(indexId);
+        assertThat(createDataSourceRequest.configuration()).isNull();
+    }
+
+    @Test
     void testTranslateToCreateRequest_WithTags() {
         String indexId = "indexId";
         ResourceModel resourceModel = ResourceModel
@@ -119,11 +133,11 @@ public class TranslatorTest {
         assertThat(updateDataSourceRequest.id()).isEqualTo(id);
         assertThat(updateDataSourceRequest.indexId()).isEqualTo(indexId);
         assertThat(updateDataSourceRequest.description()).isEqualTo("description");
-        assertThat(updateDataSourceRequest.name()).isEqualTo("");
-        assertThat(updateDataSourceRequest.roleArn()).isEqualTo("");
-        assertThat(updateDataSourceRequest.schedule()).isEqualTo("");
+        assertThat(updateDataSourceRequest.name()).isEqualTo(null);
+        assertThat(updateDataSourceRequest.roleArn()).isEqualTo(null);
+        assertThat(updateDataSourceRequest.schedule()).isEqualTo(null);
         assertThat(updateDataSourceRequest.configuration())
-                .isEqualTo(software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder().build());
+                .isEqualTo(null);
     }
 
     @Test


### PR DESCRIPTION
Problem:
Requirement to add Cloudformation support for custom_datasource

Solution:
Added cloudformation support for custom_datasource

*Description of changes:*
- Added Cloudformation support for CUSTOM datasource type 
- Current updatehandler for updating the datasource was setting RoleArn, Schedule, Description, and Name fields as blank if they were  not present in the request, which was throwing invalid RoleArn Exception during update of CUSTOM datasource type, for which RoleArn is not required. Made changes to not set them as blank and let them be null if not provided

**Testing:* 
- Tested CRUD operations on custom datasource using AWS SAM CLI in personal AWS account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
