### PR TITLE
Fix translation of cloudformation for document metadata configuration list

### DIFF
--- a/aws-kendra-index/aws-kendra-index.json
+++ b/aws-kendra-index/aws-kendra-index.json
@@ -167,6 +167,14 @@
       ]
     },
     "DocumentMetadataConfigurationList": {
+      "type": "object",
+      "properties": {
+        "DocumentMetadataConfigurationList": {
+          "$ref": "#/definitions/DocumentMetadataConfigurationListItems"
+        }
+      }
+    },
+    "DocumentMetadataConfigurationListItems": {
       "type": "array",
       "maxItems": 500,
       "items": {

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
@@ -129,7 +129,11 @@ public class Translator {
     builder.tags(tags);
     List<software.amazon.kendra.index.DocumentMetadataConfiguration> modelDocumentMetadataConfigurationList =
             translateFromSdkDocumentMetadataConfigurationList(describeIndexResponse.documentMetadataConfigurations());
-    builder.documentMetadataConfigurations(modelDocumentMetadataConfigurationList);
+    if (modelDocumentMetadataConfigurationList != null) {
+      builder.documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+              .documentMetadataConfigurationList(modelDocumentMetadataConfigurationList)
+              .build());
+    }
 
     return builder.build();
   }
@@ -149,8 +153,8 @@ public class Translator {
     String name = currModel.getName() == null ? "" : currModel.getName();
     String roleArn = currModel.getRoleArn() == null ? "" : currModel.getRoleArn();
     // Handle null previous resource model
-    List<software.amazon.kendra.index.DocumentMetadataConfiguration> prevDocumentMetadataConfiguration =
-            prevModel == null ? new ArrayList<>() : prevModel.getDocumentMetadataConfigurations();
+    software.amazon.kendra.index.DocumentMetadataConfigurationList prevDocumentMetadataConfiguration =
+            prevModel == null ? null : prevModel.getDocumentMetadataConfigurations();
     return UpdateIndexRequest
             .builder()
             .id(currModel.getId())
@@ -202,16 +206,16 @@ public class Translator {
   }
 
   static List<DocumentMetadataConfiguration> translateToSdkDocumentMetadataConfigurationList(
-          List<software.amazon.kendra.index.DocumentMetadataConfiguration> curr,
-          List<software.amazon.kendra.index.DocumentMetadataConfiguration> prev) throws TranslatorValidationException {
+          software.amazon.kendra.index.DocumentMetadataConfigurationList curr,
+          software.amazon.kendra.index.DocumentMetadataConfigurationList prev) throws TranslatorValidationException {
 
     Map<String, String> previousMetadataNames = new HashMap<>();
-    if (prev != null && !prev.isEmpty()) {
-      previousMetadataNames = prev.stream().collect(Collectors.toMap(x -> x.getName(), x -> x.getType()));
+    if (prev != null && prev.getDocumentMetadataConfigurationList() != null && !prev.getDocumentMetadataConfigurationList().isEmpty()) {
+      previousMetadataNames = prev.getDocumentMetadataConfigurationList().stream().collect(Collectors.toMap(x -> x.getName(), x -> x.getType()));
     }
     Set<String> currMetadataNames = new HashSet<>();
-    if (curr != null && !curr.isEmpty()) {
-      currMetadataNames = curr.stream().map(x -> x.getName()).collect(Collectors.toSet());
+    if (curr != null && curr.getDocumentMetadataConfigurationList() != null && !curr.getDocumentMetadataConfigurationList().isEmpty()) {
+      currMetadataNames = curr.getDocumentMetadataConfigurationList().stream().map(x -> x.getName()).collect(Collectors.toSet());
     }
     List<DocumentMetadataConfiguration> sdkDefaultAttributes = new ArrayList<>();
     for (Map.Entry<String, String> entry : previousMetadataNames.entrySet()) {
@@ -252,12 +256,13 @@ public class Translator {
   }
 
   static List<DocumentMetadataConfiguration> translateToSdkDocumentMetadataConfigurationList(
-          List<software.amazon.kendra.index.DocumentMetadataConfiguration> modelDocumentMetadataConfigurationList) throws TranslatorValidationException {
+          software.amazon.kendra.index.DocumentMetadataConfigurationList modelDocumentMetadataConfigurationList) throws TranslatorValidationException {
 
     List<DocumentMetadataConfiguration> sdkDocumentMetadataConfigurationList = new ArrayList<>();
-    if (modelDocumentMetadataConfigurationList != null && !modelDocumentMetadataConfigurationList.isEmpty()) {
+    if (modelDocumentMetadataConfigurationList != null && modelDocumentMetadataConfigurationList.getDocumentMetadataConfigurationList() != null &&
+      !modelDocumentMetadataConfigurationList.getDocumentMetadataConfigurationList().isEmpty()) {
       sdkDocumentMetadataConfigurationList = new ArrayList<>();
-      for (software.amazon.kendra.index.DocumentMetadataConfiguration modelDocumentMetadataConfiguration : modelDocumentMetadataConfigurationList) {
+      for (software.amazon.kendra.index.DocumentMetadataConfiguration modelDocumentMetadataConfiguration : modelDocumentMetadataConfigurationList.getDocumentMetadataConfigurationList()) {
         DocumentMetadataConfiguration.Builder sdkDocumentMetadataConfigurationBuilder = DocumentMetadataConfiguration.builder();
 
         sdkDocumentMetadataConfigurationBuilder.name(modelDocumentMetadataConfiguration.getName());

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/ReadHandlerTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/ReadHandlerTest.java
@@ -284,7 +284,9 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .name(name)
                 .roleArn(roleArn)
                 .edition(indexEdition)
-                .documentMetadataConfigurations(documentMetadataConfigurationList)
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(documentMetadataConfigurationList)
+                        .build())
                 .build();
         assertThat(response.getResourceModel()).isEqualTo(expected);
         assertThat(response.getResourceModels()).isNull();

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/TranslatorTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/TranslatorTest.java
@@ -41,7 +41,9 @@ class TranslatorTest {
         documentMetadataConfigurationBuilder.name(name);
 
         software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration sdkDocumentMetadataConfiguration =
-                Translator.translateToSdkDocumentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build())).get(0);
+                Translator.translateToSdkDocumentMetadataConfigurationList(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build()).get(0);
         assertThat(sdkDocumentMetadataConfiguration.name()).isEqualTo(name);
         assertThat(sdkDocumentMetadataConfiguration.type()).isNull();
         assertThat(sdkDocumentMetadataConfiguration.relevance()).isNull();
@@ -56,7 +58,9 @@ class TranslatorTest {
         documentMetadataConfigurationBuilder.type(type);
 
         software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration sdkDocumentMetadataConfiguration =
-                Translator.translateToSdkDocumentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build())).get(0);
+                Translator.translateToSdkDocumentMetadataConfigurationList(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build()).get(0);
         assertThat(sdkDocumentMetadataConfiguration.typeAsString())
                 .isEqualTo(type);
         assertThat(sdkDocumentMetadataConfiguration.name()).isNull();
@@ -90,10 +94,14 @@ class TranslatorTest {
         );
         documentMetadataConfigurationBuilder.relevance(relevanceBuilder.build());
         resourceModelBuilder.documentMetadataConfigurations(
-                Arrays.asList(documentMetadataConfigurationBuilder.build()));
+                DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build());
 
         software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration sdkDocumentMetadataConfiguration =
-                Translator.translateToSdkDocumentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build())).get(0);
+                Translator.translateToSdkDocumentMetadataConfigurationList(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build()).get(0);
         assertThat(sdkDocumentMetadataConfiguration.relevance().importance())
                 .isEqualTo(importance);
         assertThat(sdkDocumentMetadataConfiguration.relevance().duration())
@@ -123,10 +131,14 @@ class TranslatorTest {
 
         documentMetadataConfigurationBuilder.search(searchBuilder.build());
         resourceModelBuilder.documentMetadataConfigurations(
-                Arrays.asList(documentMetadataConfigurationBuilder.build()));
+                DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build());
 
         software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration sdkDocumentMetadataConfiguration =
-                Translator.translateToSdkDocumentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build())).get(0);
+                Translator.translateToSdkDocumentMetadataConfigurationList(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build()).get(0);
         assertThat(sdkDocumentMetadataConfiguration.search().displayable())
                 .isTrue();
         assertThat(sdkDocumentMetadataConfiguration.search().facetable())
@@ -341,7 +353,9 @@ class TranslatorTest {
                 .name("name")
                 .description("description")
                 .edition(IndexEdition.DEVELOPER_EDITION.toString())
-                .documentMetadataConfigurations(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build())
                 .build();
 
         UpdateIndexRequest updateIndexRequest = Translator.translateToPostCreateUpdateRequest(resourceModel);
@@ -373,7 +387,9 @@ class TranslatorTest {
                 .name("name")
                 .description("description")
                 .edition(IndexEdition.ENTERPRISE_EDITION.toString())
-                .documentMetadataConfigurations(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build())
                 .capacityUnits(CapacityUnitsConfiguration.builder()
                         .queryCapacityUnits(queryCapacityUnits)
                         .storageCapacityUnits(storageCapacityUnits)
@@ -412,7 +428,9 @@ class TranslatorTest {
                 .id(id)
                 .description(description)
                 .roleArn(roleArn)
-                .documentMetadataConfigurations(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build())
                 .edition(IndexEdition.ENTERPRISE_EDITION.toString())
                 .capacityUnits(CapacityUnitsConfiguration
                         .builder()
@@ -422,7 +440,9 @@ class TranslatorTest {
                 .build();
         ResourceModel prevModel = ResourceModel
                 .builder()
-                .documentMetadataConfigurations(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build())
                 .build();
         UpdateIndexRequest updateIndexRequest = Translator.translateToUpdateRequest(resourceModel, prevModel);
         assertThat(updateIndexRequest.id()).isEqualTo(id);
@@ -452,12 +472,16 @@ class TranslatorTest {
                 .id(id)
                 .description(description)
                 .roleArn(roleArn)
-                .documentMetadataConfigurations(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build())
                 .edition(IndexEdition.DEVELOPER_EDITION.toString())
                 .build();
         ResourceModel prevModel = ResourceModel
                 .builder()
-                .documentMetadataConfigurations(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build())
                 .build();
         UpdateIndexRequest updateIndexRequest = Translator.translateToUpdateRequest(resourceModel, prevModel);
         assertThat(updateIndexRequest.id()).isEqualTo(id);
@@ -606,9 +630,9 @@ class TranslatorTest {
         assertThat(actual.getName()).isEqualTo(name);
         assertThat(actual.getRoleArn()).isEqualTo(roleArn);
         assertThat(actual.getEdition()).isEqualTo(edition);
-        assertThat(actual.getDocumentMetadataConfigurations().size()).isEqualTo(1);
-        assertThat(actual.getDocumentMetadataConfigurations().get(0).getName()).isEqualTo(metadataName);
-        assertThat(actual.getDocumentMetadataConfigurations().get(0).getType()).isEqualTo(metadataType);
+        assertThat(actual.getDocumentMetadataConfigurations().getDocumentMetadataConfigurationList().size()).isEqualTo(1);
+        assertThat(actual.getDocumentMetadataConfigurations().getDocumentMetadataConfigurationList().get(0).getName()).isEqualTo(metadataName);
+        assertThat(actual.getDocumentMetadataConfigurations().getDocumentMetadataConfigurationList().get(0).getType()).isEqualTo(metadataType);
         assertThat(actual.getCapacityUnits().getQueryCapacityUnits()).isEqualTo(queryCapacityUnits);
         assertThat(actual.getCapacityUnits().getStorageCapacityUnits()).isEqualTo(storageCapacityUnits);
         assertThat(actual.getTags().size()).isEqualTo(1);
@@ -706,8 +730,12 @@ class TranslatorTest {
 
         assertThrows(TranslatorValidationException.class, () -> {
             Translator.translateToSdkDocumentMetadataConfigurationList(
-                    Arrays.asList(documentMetadataConfigurationBuilder.build()),
-                    Arrays.asList(documentMetadataConfigurationBuilder2.build()));
+                    DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build()))
+                        .build(),
+                    DocumentMetadataConfigurationList.builder()
+                            .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder2.build()))
+                            .build());
         });
     }
 
@@ -730,8 +758,12 @@ class TranslatorTest {
 
         List<software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration> sdkList =
                 Translator.translateToSdkDocumentMetadataConfigurationList(
-                        Arrays.asList(documentMetadataConfigurationBuilder.build(), documentMetadataConfigurationBuilder2.build()),
-                        new ArrayList<>());
+                        DocumentMetadataConfigurationList.builder()
+                                .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build(), documentMetadataConfigurationBuilder2.build()))
+                                .build(),
+                        DocumentMetadataConfigurationList.builder()
+                                .documentMetadataConfigurationList(new ArrayList<>())
+                                .build());
 
         assertThat(sdkList.size()).isEqualTo(2);
         assertThat(sdkList.get(1).name()).isEqualTo(customAttributeName);
@@ -759,9 +791,12 @@ class TranslatorTest {
 
         List<software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration> sdkList =
                 Translator.translateToSdkDocumentMetadataConfigurationList(
-                        Arrays.asList(
-                                documentMetadataConfigurationBuilder.build(),
-                                documentMetadataConfigurationBuilder2.build()), new ArrayList<>());
+                        DocumentMetadataConfigurationList.builder()
+                                .documentMetadataConfigurationList(Arrays.asList(documentMetadataConfigurationBuilder.build(), documentMetadataConfigurationBuilder2.build()))
+                                .build(),
+                        DocumentMetadataConfigurationList.builder()
+                                .documentMetadataConfigurationList(new ArrayList<>())
+                                .build());
 
         assertThat(sdkList.size()).isEqualTo(2);
     }
@@ -772,24 +807,26 @@ class TranslatorTest {
         ResourceModel resourceModel = ResourceModel
                 .builder()
                 .edition(IndexEdition.ENTERPRISE_EDITION.toString())
-                .documentMetadataConfigurations(Arrays.asList(
-                        DocumentMetadataConfiguration
-                                .builder()
-                                .relevance(Relevance
+                .documentMetadataConfigurations(DocumentMetadataConfigurationList.builder()
+                        .documentMetadataConfigurationList(Arrays.asList(
+                                DocumentMetadataConfiguration
                                         .builder()
-                                        .valueImportanceItems(Arrays.asList(
-                                                ValueImportanceItem
-                                                        .builder()
-                                                        .key("a")
-                                                        .build(),
-                                                ValueImportanceItem
-                                                        .builder()
-                                                        .key("a")
-                                                        .build())
-                                        )
-                                        .build())
-                                .build()
-                ))
+                                        .relevance(Relevance
+                                                .builder()
+                                                .valueImportanceItems(Arrays.asList(
+                                                        ValueImportanceItem
+                                                                .builder()
+                                                                .key("a")
+                                                                .build(),
+                                                        ValueImportanceItem
+                                                                .builder()
+                                                                .key("a")
+                                                                .build())
+                                                )
+                                                .build())
+                                        .build()
+                        ))
+                        .build())
                 .id(id)
                 .build();
 


### PR DESCRIPTION
*Issue #, if available:*
#77 

*Description of changes:*
This updates the type of `DocumentMetadataConfigurations` to be an object, with a single property `DocumentMetadataConfigurationList` as per the [cloudformation documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-kendra-index.html#cfn-kendra-index-documentmetadataconfigurations).

I've not touched a cloudformation resource provider before so do let me know if I've missed anything, or have got the wrong end of the stick! :)

I tested this using `mvn package`/`mvn test` - please let me know if there's anything else I can do to test this :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
