### PR TITLE
Expand refs to list types to address documentation/cdk generation error

### DIFF
--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -32,22 +32,10 @@
       ],
       "additionalProperties": false
     },
-    "TagList": {
-      "description": "List of tags",
-      "type": "array",
-      "maxItems": 200,
-      "items": {
-        "$ref": "#/definitions/Tag"
-      }
-    },
-    "DataSourceInclusionsExclusionsStrings": {
-      "type": "array",
-      "maxItems": 100,
-      "items": {
-        "type": "string",
-        "minLength": 1,
-        "maxLength": 50
-      }
+    "DataSourceInclusionsExclusionsString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 50
     },
     "S3Path": {
       "type": "object",
@@ -99,13 +87,25 @@
           "$ref": "#/definitions/S3BucketName"
         },
         "InclusionPrefixes": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "InclusionPatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "ExclusionPatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "DocumentsMetadataConfiguration": {
           "$ref": "#/definitions/DocumentsMetadataConfiguration"
@@ -186,13 +186,6 @@
         "IndexFieldName"
       ]
     },
-    "DataSourceToIndexFieldMappingList": {
-      "type": "array",
-      "maxItems": 100,
-      "items": {
-        "$ref": "#/definitions/DataSourceToIndexFieldMapping"
-      }
-    },
     "SharePointConfiguration": {
       "description": "SharePoint configuration",
       "type": "object",
@@ -220,16 +213,28 @@
           "type": "boolean"
         },
         "InclusionPatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "ExclusionPatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "VpcConfiguration": {
           "$ref": "#/definitions/DataSourceVpcConfiguration"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         },
         "DocumentTitleFieldName": {
           "$ref": "#/definitions/DataSourceFieldName"
@@ -266,10 +271,18 @@
           "$ref": "#/definitions/SalesforceStandardObjectAttachmentConfiguration"
         },
         "IncludeAttachmentFilePatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "ExcludeAttachmentFilePatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         }
       },
       "required": [
@@ -298,7 +311,11 @@
           "$ref": "#/definitions/DataSourceFieldName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         }
       },
       "required": [
@@ -332,26 +349,28 @@
       "type": "object",
       "properties": {
         "IncludedStates": {
-          "$ref": "#/definitions/SalesforceKnowledgeArticleStateList"
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 3,
+          "items": {
+            "$ref": "#/definitions/SalesforceKnowledgeArticleState"
+          }
         },
         "StandardKnowledgeArticleTypeConfiguration": {
           "$ref": "#/definitions/SalesforceStandardKnowledgeArticleTypeConfiguration"
         },
         "CustomKnowledgeArticleTypeConfigurations": {
-          "$ref": "#/definitions/SalesforceCustomKnowledgeArticleTypeConfigurationList"
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10,
+          "items": {
+            "$ref": "#/definitions/SalesforceCustomKnowledgeArticleTypeConfiguration"
+          }
         }
       },
       "required": [
         "IncludedStates"
       ]
-    },
-    "SalesforceKnowledgeArticleStateList": {
-      "type": "array",
-      "minItems": 1,
-      "maxItems": 3,
-      "items": {
-        "$ref": "#/definitions/SalesforceKnowledgeArticleState"
-      }
     },
     "SalesforceKnowledgeArticleState": {
       "type": "string",
@@ -371,20 +390,16 @@
           "$ref": "#/definitions/DataSourceFieldName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         }
       },
       "required": [
         "DocumentDataFieldName"
       ]
-    },
-    "SalesforceCustomKnowledgeArticleTypeConfigurationList": {
-      "type": "array",
-      "minItems": 1,
-      "maxItems": 10,
-      "items": {
-        "$ref": "#/definitions/SalesforceCustomKnowledgeArticleTypeConfiguration"
-      }
     },
     "SalesforceCustomKnowledgeArticleTypeConfiguration": {
       "type": "object",
@@ -399,7 +414,11 @@
           "$ref": "#/definitions/DataSourceFieldName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         }
       },
       "required": [
@@ -422,23 +441,24 @@
           "$ref": "#/definitions/DataSourceFieldName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         },
         "IncludeFilterTypes": {
-          "$ref": "#/definitions/SalesforceChatterFeedIncludeFilterTypes"
+          "type": "array",
+          "minLength": 1,
+          "maxLength": 2,
+          "items": {
+            "$ref": "#/definitions/SalesforceChatterFeedIncludeFilterType"
+          }
         }
       },
       "required": [
         "DocumentDataFieldName"
       ]
-    },
-    "SalesforceChatterFeedIncludeFilterTypes": {
-      "type": "array",
-      "minLength": 1,
-      "maxLength": 2,
-      "items": {
-        "$ref": "#/definitions/SalesforceChatterFeedIncludeFilterType"
-      }
     },
     "SalesforceChatterFeedIncludeFilterType": {
       "type": "string",
@@ -454,7 +474,11 @@
           "$ref": "#/definitions/DataSourceFieldName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         }
       }
     },
@@ -555,7 +579,11 @@
           "$ref": "#/definitions/ColumnName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         },
         "ChangeDetectingColumns": {
           "$ref": "#/definitions/ChangeDetectingColumns"
@@ -619,13 +647,25 @@
           "$ref": "#/definitions/OneDriveUsers"
         },
         "InclusionPatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "ExclusionPatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         }
       },
       "required": [
@@ -644,7 +684,12 @@
       "type": "object",
       "properties": {
         "OneDriveUserList": {
-          "$ref": "#/definitions/OneDriveUserList"
+          "type": "array",
+          "minLength": 1,
+          "maxLength": 100,
+          "items": {
+            "$ref": "#/definitions/OneDriveUser"
+          }
         },
         "OneDriveUserS3Path": {
           "$ref": "#/definitions/S3Path"
@@ -662,14 +707,6 @@
           ]
         }
       ]
-    },
-    "OneDriveUserList": {
-      "type": "array",
-      "minLength": 1,
-      "maxLength": 100,
-      "items": {
-        "$ref": "#/definitions/OneDriveUser"
-      }
     },
     "OneDriveUser": {
       "type": "string",
@@ -716,10 +753,18 @@
           "type": "boolean"
         },
         "IncludeAttachmentFilePatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "ExcludeAttachmentFilePatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "DocumentDataFieldName": {
           "$ref": "#/definitions/DataSourceFieldName"
@@ -728,7 +773,11 @@
           "$ref": "#/definitions/DataSourceFieldName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         }
       },
       "required": [
@@ -748,10 +797,18 @@
           "type": "boolean"
         },
         "IncludeAttachmentFilePatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "ExcludeAttachmentFilePatterns": {
-          "$ref": "#/definitions/DataSourceInclusionsExclusionsStrings"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceInclusionsExclusionsString"
+          }
         },
         "DocumentDataFieldName": {
           "$ref": "#/definitions/DataSourceFieldName"
@@ -760,7 +817,11 @@
           "$ref": "#/definitions/DataSourceFieldName"
         },
         "FieldMappings": {
-          "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+          "type": "array",
+          "maxItems": 100,
+          "items": {
+            "$ref": "#/definitions/DataSourceToIndexFieldMapping"
+          }
         }
       },
       "required": [
@@ -900,7 +961,11 @@
     },
     "Tags": {
       "description": "Tags for labeling the data source",
-      "$ref": "#/definitions/TagList"
+      "type": "array",
+      "maxItems": 200,
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
     }
   },
   "required": [

--- a/aws-kendra-faq/aws-kendra-faq.json
+++ b/aws-kendra-faq/aws-kendra-faq.json
@@ -26,14 +26,6 @@
       ],
       "additionalProperties": false
     },
-    "TagList": {
-      "description": "List of tags",
-      "type": "array",
-      "maxItems": 200,
-      "items": {
-        "$ref": "#/definitions/Tag"
-      }
-    },
     "IndexId": {
       "description": "Unique ID of Index",
       "type": "string",
@@ -129,7 +121,11 @@
     },
     "Tags": {
       "description": "Tags for labeling the FAQ",
-      "$ref": "#/definitions/TagList"
+      "type": "array",
+      "maxItems": 200,
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
     },
     "Arn": {
       "type": "string",

--- a/aws-kendra-index/aws-kendra-index.json
+++ b/aws-kendra-index/aws-kendra-index.json
@@ -43,14 +43,6 @@
       ],
       "additionalProperties": false
     },
-    "TagList": {
-      "description": "List of tags",
-      "type": "array",
-      "maxItems": 200,
-      "items": {
-        "$ref": "#/definitions/Tag"
-      }
-    },
     "Importance": {
       "type": "integer",
       "minimum": 1,
@@ -88,14 +80,11 @@
           "$ref": "#/definitions/Order"
         },
         "ValueImportanceItems": {
-          "$ref": "#/definitions/ValueImportanceItems"
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ValueImportanceItem"
+          }
         }
-      }
-    },
-    "ValueImportanceItems": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/ValueImportanceItem"
       }
     },
     "ValueImportanceItem": {
@@ -165,13 +154,6 @@
         "Name",
         "Type"
       ]
-    },
-    "DocumentMetadataConfigurationList": {
-      "type": "array",
-      "maxItems": 500,
-      "items": {
-        "$ref": "#/definitions/DocumentMetadataConfiguration"
-      }
     },
     "StorageCapacityUnits": {
       "type": "integer",
@@ -245,7 +227,11 @@
     },
     "Tags": {
       "description": "Tags for labeling the index",
-      "$ref": "#/definitions/TagList"
+      "type": "array",
+      "maxItems": 200,
+      "items": {
+        "$ref": "#/definitions/Tag"
+      }
     },
     "Name": {
       "$ref": "#/definitions/Name"
@@ -258,7 +244,11 @@
     },
     "DocumentMetadataConfigurations": {
       "description": "Document metadata configurations",
-      "$ref": "#/definitions/DocumentMetadataConfigurationList"
+      "type": "array",
+      "maxItems": 500,
+      "items": {
+        "$ref": "#/definitions/DocumentMetadataConfiguration"
+      }
     },
     "CapacityUnits": {
       "description": "Capacity units",


### PR DESCRIPTION
*Issue #, if available:*
#77 

*Description of changes:*
Looking at some other examples of resource providers and the generated documentation, it appears that a `$ref` to an `array` type generates the object with a single list property, whereas when the `array` type is specified at the top level, it generates an array as expected.

This PR "expands" the array references.

Worth waiting for confirmation from the cloudformation team before merging as it's just my theory of the problem right now, and this is a workaround rather than addressing the root cause! :)

### Another Example of this Issue
The same issue is present for IoT Provisioning Template tags - the Tags type is an object with a Tags property that's then a list:

Resource definition:
* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-iot/blob/master/aws-iot-provisioningtemplate/aws-iot-provisioningtemplate.json#L63

Documentation:
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-iot-provisioningtemplate.html#cfn-iot-provisioningtemplate-tags
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-iot-provisioningtemplate-tags.html

### A Correctly Generated Example

Resource definition:
* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-acmpca/blob/e3c591cddff371786b4dacaaef1d02b938b121c7/aws-acmpca-certificateauthority/aws-acmpca-certificateauthority.json#L124

Documentation:
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-acmpca-certificateauthority.html#cfn-acmpca-certificateauthority-tags

---



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
