### PR TITLE
Add cloudformation support for UserContext

### DIFF
--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -193,6 +193,9 @@
         "$ref": "#/definitions/DataSourceToIndexFieldMapping"
       }
     },
+    "DisableLocalGroups": {
+      "type": "boolean"
+    },
     "SharePointConfiguration": {
       "description": "SharePoint configuration",
       "type": "object",
@@ -233,6 +236,9 @@
         },
         "DocumentTitleFieldName": {
           "$ref": "#/definitions/DataSourceFieldName"
+        },
+        "DisableLocalGroups": {
+          "$ref": "#/definitions/DisableLocalGroups"
         }
       },
       "required": [
@@ -626,6 +632,9 @@
         },
         "FieldMappings": {
           "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+        },
+        "DisableLocalGroups": {
+          "$ref": "#/definitions/DisableLocalGroups"
         }
       },
       "required": [

--- a/aws-kendra-datasource/pom.xml
+++ b/aws-kendra-datasource/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kendra</artifactId>
-            <version>2.15.12</version>
+            <version>2.15.23</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/OneDriveConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/OneDriveConverter.java
@@ -17,6 +17,7 @@ public class OneDriveConverter {
                 .exclusionPatterns(StringListConverter.toSdk(model.getExclusionPatterns()))
                 .fieldMappings(ListConverter.toSdk(model.getFieldMappings(), FieldMappingConverter::toSdk))
                 .oneDriveUsers(toSdk(model.getOneDriveUsers()))
+                .disableLocalGroups(model.getDisableLocalGroups())
                 .build();
     }
 
@@ -60,6 +61,7 @@ public class OneDriveConverter {
                 .inclusionPatterns(StringListConverter.toModel(sdk.inclusionPatterns()))
                 .exclusionPatterns(StringListConverter.toModel(sdk.exclusionPatterns()))
                 .oneDriveUsers(toModel(sdk.oneDriveUsers()))
+                .disableLocalGroups(sdk.disableLocalGroups())
                 .build();
     }
 

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/SharePointConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/SharePointConverter.java
@@ -21,6 +21,7 @@ public class SharePointConverter {
             .vpcConfiguration(sdkVpcConfiguration(model.getVpcConfiguration()))
             .fieldMappings(ListConverter.toSdk(model.getFieldMappings(), FieldMappingConverter::toSdk))
             .documentTitleFieldName(model.getDocumentTitleFieldName())
+            .disableLocalGroups(model.getDisableLocalGroups())
             .build();
   }
 
@@ -46,6 +47,7 @@ public class SharePointConverter {
             .vpcConfiguration(modelVpcConfiguration(sdk.vpcConfiguration()))
             .fieldMappings(ListConverter.toModel(sdk.fieldMappings(), FieldMappingConverter::toModel))
             .documentTitleFieldName(sdk.documentTitleFieldName())
+            .disableLocalGroups(sdk.disableLocalGroups())
             .build();
   }
 

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/OneDriveTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/OneDriveTest.java
@@ -24,6 +24,7 @@ public class OneDriveTest {
                 .secretArn(secretArn)
                 .inclusionPatterns(includes)
                 .exclusionPatterns(excludes)
+                .disableLocalGroups(true)
                 .build();
 
         software.amazon.awssdk.services.kendra.model.OneDriveConfiguration sdk =
@@ -32,6 +33,7 @@ public class OneDriveTest {
                 .tenantDomain(tenantDomain)
                 .inclusionPatterns(includes)
                 .exclusionPatterns(excludes)
+                .disableLocalGroups(true)
                 .build();
 
         assertThat(OneDriveConverter.toSdkDataSourceConfiguration(model)).isEqualTo(sdk);
@@ -85,6 +87,7 @@ public class OneDriveTest {
                 .secretArn(secretArn)
                 .inclusionPatterns(includes)
                 .exclusionPatterns(excludes)
+                .disableLocalGroups(false)
                 .build();
 
         software.amazon.awssdk.services.kendra.model.OneDriveConfiguration sdk =
@@ -93,6 +96,7 @@ public class OneDriveTest {
                         .tenantDomain(tenantDomain)
                         .inclusionPatterns(includes)
                         .exclusionPatterns(excludes)
+                        .disableLocalGroups(false)
                         .build();
 
         assertThat(OneDriveConverter.toModel(sdk)).isEqualTo(model);

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/SharePointConverterTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/SharePointConverterTest.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SharePointCoverterTest {
+public class SharePointConverterTest {
 
   @Test
   public void testSdkDataSourceConfiguration() {
@@ -28,6 +28,7 @@ public class SharePointCoverterTest {
           .securityGroupIds(Arrays.asList("testSecurityGroupId"))
           .subnetIds(Arrays.asList("testSubnetId"))
           .build())
+        .disableLocalGroups(true)
         .fieldMappings(Arrays.asList(DataSourceToIndexFieldMapping.builder()
           .dataSourceFieldName("testDataSourceFieldName")
           .dateFieldFormat("testDateFieldFormat")
@@ -56,6 +57,7 @@ public class SharePointCoverterTest {
                         .indexFieldName("testIndexFieldName")
                         .build()))
                 .documentTitleFieldName("testDocumentTitleFieldName")
+                .disableLocalGroups(true)
                 .build();
 
     assertThat(SharePointConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getSharePointConfiguration()))
@@ -71,6 +73,7 @@ public class SharePointCoverterTest {
         .secretArn("secretArn")
         .crawlAttachments(true)
         .useChangeLog(true)
+        .disableLocalGroups(false)
         .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
         .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
         .documentTitleFieldName("testDocumentTitleFieldName")
@@ -84,6 +87,7 @@ public class SharePointCoverterTest {
                     .secretArn("secretArn")
                     .crawlAttachments(true)
                     .useChangeLog(true)
+                    .disableLocalGroups(false)
                     .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
                     .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
                     .documentTitleFieldName("testDocumentTitleFieldName")
@@ -103,6 +107,7 @@ public class SharePointCoverterTest {
           .secretArn("secretArn")
           .crawlAttachments(true)
           .useChangeLog(true)
+          .disableLocalGroups(true)
           .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
           .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
           .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
@@ -125,6 +130,7 @@ public class SharePointCoverterTest {
         .secretArn("secretArn")
         .crawlAttachments(true)
         .useChangeLog(true)
+        .disableLocalGroups(true)
         .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
         .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
         .vpcConfiguration( DataSourceVpcConfiguration.builder()

--- a/aws-kendra-index/aws-kendra-index.json
+++ b/aws-kendra-index/aws-kendra-index.json
@@ -226,6 +226,108 @@
     "Arn": {
       "type": "string",
       "maxLength": 1000
+    },
+    "UserContextPolicy": {
+      "type": "string",
+      "enum": [
+        "ATTRIBUTE_FILTER",
+        "USER_TOKEN"
+      ]
+    },
+    "UserNameAttributeField": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "GroupAttributeField": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "KeyLocation": {
+      "type": "string",
+      "enum": [
+        "URL",
+        "SECRET_MANAGER"
+      ]
+    },
+    "Issuer": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 65
+    },
+    "ClaimRegex": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 100
+    },
+    "Url": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048,
+      "pattern": "^(https?|ftp|file):\\/\\/([^\\s]*)"
+    },
+    "JsonTokenTypeConfiguration": {
+      "type": "object",
+      "properties": {
+        "UserNameAttributeField": {
+          "$ref": "#/definitions/UserNameAttributeField"
+        },
+        "GroupAttributeField": {
+          "$ref": "#/definitions/GroupAttributeField"
+        }
+      },
+      "required": [
+        "UserNameAttributeField",
+        "GroupAttributeField"
+      ]
+    },
+    "JwtTokenTypeConfiguration": {
+      "type": "object",
+      "properties": {
+        "KeyLocation": {
+          "$ref": "#/definitions/KeyLocation"
+        },
+        "URL": {
+          "$ref": "#/definitions/Url"
+        },
+        "SecretManagerArn": {
+          "$ref": "#/definitions/RoleArn"
+        },
+        "UserNameAttributeField": {
+          "$ref": "#/definitions/UserNameAttributeField"
+        },
+        "GroupAttributeField": {
+          "$ref": "#/definitions/GroupAttributeField"
+        },
+        "Issuer": {
+          "$ref": "#/definitions/Issuer"
+        },
+        "ClaimRegex": {
+          "$ref": "#/definitions/ClaimRegex"
+        }
+      },
+      "required": [
+        "KeyLocation"
+      ]
+    },
+    "UserTokenConfiguration": {
+      "type": "object",
+      "properties": {
+        "JwtTokenTypeConfiguration": {
+          "$ref": "#/definitions/JwtTokenTypeConfiguration"
+        },
+        "JsonTokenTypeConfiguration": {
+          "$ref": "#/definitions/JsonTokenTypeConfiguration"
+        }
+      }
+    },
+    "UserTokenConfigurationList": {
+      "type": "array",
+      "maxItems": 1,
+      "items": {
+        "$ref": "#/definitions/UserTokenConfiguration"
+      }
     }
   },
   "properties": {
@@ -263,6 +365,12 @@
     "CapacityUnits": {
       "description": "Capacity units",
       "$ref": "#/definitions/CapacityUnitsConfiguration"
+    },
+    "UserContextPolicy": {
+      "$ref": "#/definitions/UserContextPolicy"
+    },
+    "UserTokenConfigurations": {
+      "$ref": "#/definitions/UserTokenConfigurationList"
     }
   },
   "required": [

--- a/aws-kendra-index/pom.xml
+++ b/aws-kendra-index/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kendra</artifactId>
-            <version>2.13.63</version>
+            <version>2.15.23</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
@@ -18,6 +18,9 @@ import software.amazon.awssdk.services.kendra.model.Tag;
 import software.amazon.awssdk.services.kendra.model.TagResourceRequest;
 import software.amazon.awssdk.services.kendra.model.UntagResourceRequest;
 import software.amazon.awssdk.services.kendra.model.UpdateIndexRequest;
+import software.amazon.awssdk.services.kendra.model.UserTokenConfiguration;
+import software.amazon.awssdk.services.kendra.model.JsonTokenTypeConfiguration;
+import software.amazon.awssdk.services.kendra.model.JwtTokenTypeConfiguration;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,7 +48,8 @@ public class Translator {
             .name(model.getName())
             .roleArn(model.getRoleArn())
             .description(model.getDescription())
-            .edition(model.getEdition());
+            .edition(model.getEdition())
+            .userTokenConfigurations(translateToSdkUserTokenConfigurations(model.getUserTokenConfigurations()));
     builder.tags(ListConverter.toSdk(model.getTags(), x -> Tag.builder().key(x.getKey()).value(x.getValue()).build()));
     if (model.getServerSideEncryptionConfiguration() != null
             && (model.getServerSideEncryptionConfiguration().getKmsKeyId() != null)) {
@@ -54,6 +58,9 @@ public class Translator {
                       .builder()
                       .kmsKeyId(model.getServerSideEncryptionConfiguration().getKmsKeyId())
                       .build());
+    }
+    if (model.getUserContextPolicy() != null) {
+      builder.userContextPolicy(model.getUserContextPolicy());
     }
     return builder.build();
   }
@@ -102,7 +109,8 @@ public class Translator {
             .name(describeIndexResponse.name())
             .roleArn(describeIndexResponse.roleArn())
             .description(describeIndexResponse.description())
-            .edition(describeIndexResponse.edition().toString());
+            .edition(describeIndexResponse.edition().toString())
+            .userContextPolicy(describeIndexResponse.userContextPolicy() == null ? null : describeIndexResponse.userContextPolicy().toString());
     if (describeIndexResponse.serverSideEncryptionConfiguration() != null
             && (describeIndexResponse.serverSideEncryptionConfiguration().kmsKeyId() != null)) {
       builder.serverSideEncryptionConfiguration(
@@ -123,6 +131,8 @@ public class Translator {
                 .queryCapacityUnits(describeIndexResponse.capacityUnits().queryCapacityUnits())
                 .build());
       }
+    } if (describeIndexResponse.hasUserTokenConfigurations()) {
+      builder.userTokenConfigurations(translateFromSdkUserTokenConfigurations(describeIndexResponse.userTokenConfigurations()));
     }
     List<software.amazon.kendra.index.Tag> tags = ListConverter.toModel(listTagsForResourceResponse.tags(),
             x -> software.amazon.kendra.index.Tag.builder().key(x.key()).value(x.value()).build());
@@ -151,7 +161,8 @@ public class Translator {
     // Handle null previous resource model
     List<software.amazon.kendra.index.DocumentMetadataConfiguration> prevDocumentMetadataConfiguration =
             prevModel == null ? new ArrayList<>() : prevModel.getDocumentMetadataConfigurations();
-    return UpdateIndexRequest
+
+    final UpdateIndexRequest.Builder builder = UpdateIndexRequest
             .builder()
             .id(currModel.getId())
             .roleArn(roleArn)
@@ -162,7 +173,11 @@ public class Translator {
                             currModel.getDocumentMetadataConfigurations(),
                             prevDocumentMetadataConfiguration))
             .capacityUnits(translateToCapacityUnitsConfiguration(currModel.getCapacityUnits(), currModel.getEdition()))
-            .build();
+            .userTokenConfigurations(translateToSdkUserTokenConfigurations(currModel.getUserTokenConfigurations()));
+    if (currModel.getUserContextPolicy() != null) {
+      builder.userContextPolicy(currModel.getUserContextPolicy());
+    }
+    return builder.build();
   }
 
   static CapacityUnitsConfiguration translateToCapacityUnitsConfiguration(
@@ -388,5 +403,89 @@ public class Translator {
     return Optional.ofNullable(collection)
             .map(Collection::stream)
             .orElseGet(Stream::empty);
+  }
+
+  private static List<UserTokenConfiguration> translateToSdkUserTokenConfigurations(List<software.amazon.kendra.index.UserTokenConfiguration> modelUserTokenConfigurations) {
+    if (modelUserTokenConfigurations != null && !modelUserTokenConfigurations.isEmpty()) {
+      return modelUserTokenConfigurations
+          .stream()
+          .map(x -> UserTokenConfiguration.builder()
+              .jsonTokenTypeConfiguration(translateToSdkJsonTokenTypeConfiguration(x.getJsonTokenTypeConfiguration()))
+              .jwtTokenTypeConfiguration(translateToSdkJwtTokenTypeConfiguration(x.getJwtTokenTypeConfiguration()))
+              .build())
+          .collect(Collectors.toList());
+    } else {
+      return null;
+    }
+  }
+
+  private static JsonTokenTypeConfiguration translateToSdkJsonTokenTypeConfiguration(software.amazon.kendra.index.JsonTokenTypeConfiguration modelJsonTokenTypeConfiguration) {
+    if (modelJsonTokenTypeConfiguration != null) {
+      JsonTokenTypeConfiguration.Builder sdkJsonTokenTypeConfigurationBuilder = JsonTokenTypeConfiguration.builder();
+      sdkJsonTokenTypeConfigurationBuilder.userNameAttributeField(modelJsonTokenTypeConfiguration.getUserNameAttributeField());
+      sdkJsonTokenTypeConfigurationBuilder.groupAttributeField(modelJsonTokenTypeConfiguration.getGroupAttributeField());
+      return sdkJsonTokenTypeConfigurationBuilder.build();
+    } else {
+      return null;
+    }
+  }
+
+  private static JwtTokenTypeConfiguration translateToSdkJwtTokenTypeConfiguration(software.amazon.kendra.index.JwtTokenTypeConfiguration modelJwtTokenTypeConfiguration) {
+    if (modelJwtTokenTypeConfiguration != null) {
+      JwtTokenTypeConfiguration.Builder sdkJwtTokenTypeConfigurationBuilder = JwtTokenTypeConfiguration.builder();
+      sdkJwtTokenTypeConfigurationBuilder.keyLocation(modelJwtTokenTypeConfiguration.getKeyLocation());
+      sdkJwtTokenTypeConfigurationBuilder.url(modelJwtTokenTypeConfiguration.getURL());
+      sdkJwtTokenTypeConfigurationBuilder.secretManagerArn(modelJwtTokenTypeConfiguration.getSecretManagerArn());
+      sdkJwtTokenTypeConfigurationBuilder.issuer(modelJwtTokenTypeConfiguration.getIssuer());
+      sdkJwtTokenTypeConfigurationBuilder.claimRegex(modelJwtTokenTypeConfiguration.getClaimRegex());
+      sdkJwtTokenTypeConfigurationBuilder.userNameAttributeField(modelJwtTokenTypeConfiguration.getUserNameAttributeField());
+      sdkJwtTokenTypeConfigurationBuilder.groupAttributeField(modelJwtTokenTypeConfiguration.getGroupAttributeField());
+      return sdkJwtTokenTypeConfigurationBuilder.build();
+    } else {
+      return null;
+    }
+  }
+
+  private static List<software.amazon.kendra.index.UserTokenConfiguration> translateFromSdkUserTokenConfigurations(List<UserTokenConfiguration> sdkUserTokenConfigurations) {
+    if (sdkUserTokenConfigurations != null && !sdkUserTokenConfigurations.isEmpty()) {
+      return sdkUserTokenConfigurations
+          .stream()
+          .map(x -> software.amazon.kendra.index.UserTokenConfiguration.builder()
+              .jsonTokenTypeConfiguration(translateFromSdkJsonTokenTypeConfiguration(x.jsonTokenTypeConfiguration()))
+              .jwtTokenTypeConfiguration(translateFromSdkJwtTokenTypeConfiguration(x.jwtTokenTypeConfiguration()))
+              .build())
+          .collect(Collectors.toList());
+    } else {
+      return null;
+    }
+  }
+
+  private static software.amazon.kendra.index.JsonTokenTypeConfiguration translateFromSdkJsonTokenTypeConfiguration(JsonTokenTypeConfiguration sdkJsonTokenTypeConfiguration) {
+    if (sdkJsonTokenTypeConfiguration != null) {
+      software.amazon.kendra.index.JsonTokenTypeConfiguration.JsonTokenTypeConfigurationBuilder modelJsonTokenTypeConfigurationBuilder =
+          software.amazon.kendra.index.JsonTokenTypeConfiguration.builder();
+      modelJsonTokenTypeConfigurationBuilder.userNameAttributeField(sdkJsonTokenTypeConfiguration.userNameAttributeField());
+      modelJsonTokenTypeConfigurationBuilder.groupAttributeField(sdkJsonTokenTypeConfiguration.groupAttributeField());
+      return modelJsonTokenTypeConfigurationBuilder.build();
+    } else {
+      return null;
+    }
+  }
+
+  private static software.amazon.kendra.index.JwtTokenTypeConfiguration translateFromSdkJwtTokenTypeConfiguration(JwtTokenTypeConfiguration sdkJwtTokenTypeConfiguration) {
+    if (sdkJwtTokenTypeConfiguration != null) {
+      software.amazon.kendra.index.JwtTokenTypeConfiguration.JwtTokenTypeConfigurationBuilder modelJwtTokenTypeConfigurationBuilder =
+          software.amazon.kendra.index.JwtTokenTypeConfiguration.builder();
+      modelJwtTokenTypeConfigurationBuilder.keyLocation(sdkJwtTokenTypeConfiguration.keyLocation().toString());
+      modelJwtTokenTypeConfigurationBuilder.uRL(sdkJwtTokenTypeConfiguration.url());
+      modelJwtTokenTypeConfigurationBuilder.secretManagerArn(sdkJwtTokenTypeConfiguration.secretManagerArn());
+      modelJwtTokenTypeConfigurationBuilder.issuer(sdkJwtTokenTypeConfiguration.issuer());
+      modelJwtTokenTypeConfigurationBuilder.claimRegex(sdkJwtTokenTypeConfiguration.claimRegex());
+      modelJwtTokenTypeConfigurationBuilder.userNameAttributeField(sdkJwtTokenTypeConfiguration.userNameAttributeField());
+      modelJwtTokenTypeConfigurationBuilder.groupAttributeField(sdkJwtTokenTypeConfiguration.groupAttributeField());
+      return modelJwtTokenTypeConfigurationBuilder.build();
+    } else {
+      return null;
+    }
   }
 }

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/CreateHandlerTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/CreateHandlerTest.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.services.kendra.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.kendra.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.kendra.model.UpdateIndexRequest;
 import software.amazon.awssdk.services.kendra.model.UpdateIndexResponse;
+import software.amazon.awssdk.services.kendra.model.UserContextPolicy;
 import software.amazon.awssdk.services.kendra.model.ValidationException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
@@ -383,6 +384,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         String roleArn = "testRoleArn";
         String indexEdition = IndexEdition.ENTERPRISE_EDITION.toString();
         String kmsKeyId = "kmsKeyId";
+        String userContextPolicy = UserContextPolicy.ATTRIBUTE_FILTER.toString();
         ServerSideEncryptionConfiguration serverSideEncryptionConfiguration =
                 ServerSideEncryptionConfiguration.builder().kmsKeyId(kmsKeyId).build();
         final ResourceModel model = ResourceModel
@@ -390,6 +392,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .name(name)
                 .roleArn(roleArn)
                 .edition(indexEdition)
+                .userContextPolicy(userContextPolicy)
                 .serverSideEncryptionConfiguration(serverSideEncryptionConfiguration)
                 .build();
 
@@ -406,6 +409,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                         .name(name)
                         .roleArn(roleArn)
                         .edition(indexEdition)
+                        .userContextPolicy(userContextPolicy)
                         .status(IndexStatus.ACTIVE.toString())
                         .serverSideEncryptionConfiguration(
                                 software.amazon.awssdk.services.kendra.model.ServerSideEncryptionConfiguration
@@ -430,6 +434,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .name(name)
                 .roleArn(roleArn)
                 .edition(indexEdition)
+                .userContextPolicy(userContextPolicy)
                 .serverSideEncryptionConfiguration(serverSideEncryptionConfiguration)
                 .build();
         assertThat(response.getResourceModel()).isEqualTo(expectedResourceModel);

--- a/aws-kendra-index/src/test/java/software/amazon/kendra/index/ReadHandlerTest.java
+++ b/aws-kendra-index/src/test/java/software/amazon/kendra/index/ReadHandlerTest.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.kendra.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.kendra.model.ResourceInUseException;
 import software.amazon.awssdk.services.kendra.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.kendra.model.Tag;
+import software.amazon.awssdk.services.kendra.model.UserContextPolicy;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -72,6 +73,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         String name = "testName";
         String roleArn = "testRoleArn";
         String indexEdition = IndexEdition.ENTERPRISE_EDITION.toString();
+        String userContextPolicy = UserContextPolicy.ATTRIBUTE_FILTER.toString();
 
         when(proxyClient.client().describeIndex(any(DescribeIndexRequest.class)))
                 .thenReturn(DescribeIndexResponse.builder()
@@ -80,6 +82,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                         .roleArn(roleArn)
                         .edition(indexEdition)
                         .status(IndexStatus.ACTIVE.toString())
+                        .userContextPolicy(userContextPolicy)
                         .build());
 
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
@@ -105,6 +108,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .name(name)
                 .roleArn(roleArn)
                 .edition(indexEdition)
+                .userContextPolicy(userContextPolicy)
                 .build();
         assertThat(response.getResourceModel()).isEqualTo(expected);
         assertThat(response.getResourceModels()).isNull();
@@ -123,6 +127,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         String name = "testName";
         String roleArn = "testRoleArn";
         String indexEdition = IndexEdition.ENTERPRISE_EDITION.toString();
+        String userContextPolicy = UserContextPolicy.ATTRIBUTE_FILTER.toString();
 
         when(proxyClient.client().describeIndex(any(DescribeIndexRequest.class)))
                 .thenReturn(DescribeIndexResponse.builder()
@@ -131,6 +136,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                         .roleArn(roleArn)
                         .edition(indexEdition)
                         .status(IndexStatus.ACTIVE.toString())
+                        .userContextPolicy(userContextPolicy)
                         .build());
 
         String key = "key";
@@ -162,6 +168,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .roleArn(roleArn)
                 .edition(indexEdition)
                 .tags(Arrays.asList(software.amazon.kendra.index.Tag.builder().key(key).value(value).build()))
+                .userContextPolicy(userContextPolicy)
                 .build();
         assertThat(response.getResourceModel()).isEqualTo(expected);
         assertThat(response.getResourceModels()).isNull();
@@ -201,6 +208,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         String name = "testName";
         String roleArn = "testRoleArn";
         String indexEdition = IndexEdition.ENTERPRISE_EDITION.toString();
+        String userContextPolicy = UserContextPolicy.ATTRIBUTE_FILTER.toString();
 
         when(proxyClient.client().describeIndex(any(DescribeIndexRequest.class)))
                 .thenReturn(DescribeIndexResponse.builder()
@@ -209,6 +217,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                         .roleArn(roleArn)
                         .edition(indexEdition)
                         .status(IndexStatus.ACTIVE.toString())
+                        .userContextPolicy(userContextPolicy)
                         .build());
 
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
@@ -239,6 +248,7 @@ public class ReadHandlerTest extends AbstractTestBase {
         String indexEdition = IndexEdition.ENTERPRISE_EDITION.toString();
         String documentMetadataConfigurationName = "documentMetadataConfigurationName";
         String documentMetadataConfigurationType = "documentMetadataConfigurationType";
+        String userContextPolicy = UserContextPolicy.ATTRIBUTE_FILTER.toString();
 
         List<software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration> sdkDocumentMetadataConfigurationList =
                 Arrays.asList(software.amazon.awssdk.services.kendra.model.DocumentMetadataConfiguration
@@ -251,6 +261,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                         .edition(indexEdition)
                         .status(IndexStatus.ACTIVE.toString())
                         .documentMetadataConfigurations(sdkDocumentMetadataConfigurationList)
+                        .userContextPolicy(userContextPolicy)
                         .build());
 
         when(proxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class)))
@@ -285,6 +296,7 @@ public class ReadHandlerTest extends AbstractTestBase {
                 .roleArn(roleArn)
                 .edition(indexEdition)
                 .documentMetadataConfigurations(documentMetadataConfigurationList)
+                .userContextPolicy(userContextPolicy)
                 .build();
         assertThat(response.getResourceModel()).isEqualTo(expected);
         assertThat(response.getResourceModels()).isNull();


### PR DESCRIPTION
*Issue #, if available:*
Add support to create kendra index with user context configurations.
*Description of changes:*
Added support to create/update/read kendra index with user context configurations via cloudformation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
