### PR TITLE
ServiceNow OAuth2, FilterQuery, & Bug Fixes

### DIFF
--- a/aws-kendra-datasource/.rpdk-config
+++ b/aws-kendra-datasource/.rpdk-config
@@ -1,4 +1,5 @@
 {
+    "artifact_type": "RESOURCE",
     "typeName": "AWS::Kendra::DataSource",
     "language": "java",
     "runtime": "java8",
@@ -13,5 +14,6 @@
         ],
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
-    }
+    },
+    "executableEntrypoint": "software.amazon.kendra.datasource.HandlerWrapperExecutable"
 }

--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -459,8 +459,8 @@
     },
     "SalesforceChatterFeedIncludeFilterTypes": {
       "type": "array",
-      "minLength": 1,
-      "maxLength": 2,
+      "minItems": 1,
+      "maxItems": 2,
       "items": {
         "$ref": "#/definitions/SalesforceChatterFeedIncludeFilterType"
       }
@@ -701,8 +701,8 @@
     },
     "OneDriveUserList": {
       "type": "array",
-      "minLength": 1,
-      "maxLength": 100,
+      "minItems": 1,
+      "maxItems": 100,
       "items": {
         "$ref": "#/definitions/OneDriveUser"
       }
@@ -725,6 +725,9 @@
         "ServiceNowBuildVersion": {
           "$ref": "#/definitions/ServiceNowBuildVersionType"
         },
+        "AuthenticationType": {
+          "$ref": "#/definitions/ServiceNowAuthenticationType"
+        },
         "KnowledgeArticleConfiguration": {
           "$ref": "#/definitions/ServiceNowKnowledgeArticleConfiguration"
         },
@@ -744,6 +747,13 @@
       "enum": [
         "LONDON",
         "OTHERS"
+      ]
+    },
+    "ServiceNowAuthenticationType": {
+      "type": "string",
+      "enum": [
+        "HTTP_BASIC",
+        "OAUTH2"
       ]
     },
     "ServiceNowServiceCatalogConfiguration": {
@@ -799,12 +809,20 @@
         },
         "FieldMappings": {
           "$ref": "#/definitions/DataSourceToIndexFieldMappingList"
+        },
+        "FilterQuery": {
+          "$ref": "#/definitions/ServiceNowKnowledgeArticleFilterQuery"
         }
       },
       "additionalProperties": false,
       "required": [
         "DocumentDataFieldName"
       ]
+    },
+    "ServiceNowKnowledgeArticleFilterQuery": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048
     },
     "ConfluenceConfiguration": {
       "type": "object",
@@ -1090,14 +1108,15 @@
           "$ref": "#/definitions/ExcludeSharedDrivesList"
         }
       },
+      "additionalProperties": false,
       "required": [
         "SecretArn"
       ]
     },
     "ExcludeMimeTypesList": {
       "type": "array",
-      "minLength": 0,
-      "maxLength": 30,
+      "minItems": 0,
+      "maxItems": 30,
       "items": {
         "$ref": "#/definitions/MimeType"
       }
@@ -1109,8 +1128,8 @@
     },
     "ExcludeUserAccountsList": {
       "type": "array",
-      "minLength": 0,
-      "maxLength": 100,
+      "minItems": 0,
+      "maxItems": 100,
       "items": {
         "$ref": "#/definitions/UserAccount"
       }
@@ -1122,8 +1141,8 @@
     },
     "ExcludeSharedDrivesList": {
       "type": "array",
-      "minLength": 0,
-      "maxLength": 100,
+      "minItems": 0,
+      "maxItems": 100,
       "items": {
         "$ref": "#/definitions/SharedDriveId"
       }

--- a/aws-kendra-datasource/pom.xml
+++ b/aws-kendra-datasource/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kendra</artifactId>
-            <version>2.15.58</version>
+            <version>2.16.33</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/ServiceNowConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/ServiceNowConverter.java
@@ -16,6 +16,7 @@ public class ServiceNowConverter {
                 .hostUrl(model.getHostUrl())
                 .secretArn(model.getSecretArn())
                 .serviceNowBuildVersion(model.getServiceNowBuildVersion())
+                .authenticationType(model.getAuthenticationType())
                 .knowledgeArticleConfiguration(toSdk(model.getKnowledgeArticleConfiguration()))
                 .serviceCatalogConfiguration(toSdk(model.getServiceCatalogConfiguration()))
                 .build();
@@ -34,6 +35,7 @@ public class ServiceNowConverter {
                 .fieldMappings(ListConverter.toSdk(model.getFieldMappings(), FieldMappingConverter::toSdk))
                 .includeAttachmentFilePatterns(StringListConverter.toSdk(model.getIncludeAttachmentFilePatterns()))
                 .excludeAttachmentFilePatterns(StringListConverter.toSdk(model.getExcludeAttachmentFilePatterns()))
+                .filterQuery(model.getFilterQuery())
                 .build();
     }
 
@@ -69,6 +71,7 @@ public class ServiceNowConverter {
                 .hostUrl(sdk.hostUrl())
                 .secretArn(sdk.secretArn())
                 .serviceNowBuildVersion(sdk.serviceNowBuildVersionAsString())
+                .authenticationType(sdk.authenticationTypeAsString())
                 .knowledgeArticleConfiguration(toModel(sdk.knowledgeArticleConfiguration()))
                 .serviceCatalogConfiguration(toModel(sdk.serviceCatalogConfiguration()))
                 .build();
@@ -83,9 +86,10 @@ public class ServiceNowConverter {
                 .crawlAttachments(sdk.crawlAttachments())
                 .documentDataFieldName(sdk.documentDataFieldName())
                 .documentTitleFieldName(sdk.documentTitleFieldName())
-                .fieldMappings(ListConverter.toSdk(sdk.fieldMappings(), FieldMappingConverter::toModel))
+                .fieldMappings(ListConverter.toModel(sdk.fieldMappings(), FieldMappingConverter::toModel))
                 .includeAttachmentFilePatterns(StringListConverter.toModel(sdk.includeAttachmentFilePatterns()))
                 .excludeAttachmentFilePatterns(StringListConverter.toModel(sdk.excludeAttachmentFilePatterns()))
+                .filterQuery(sdk.filterQuery())
                 .build();
     }
 


### PR DESCRIPTION
Changelog:

- Added authentication type support for service now configuration
- Added filter query support for service now knowledge article configuration
- Fixed issue where empty knowledge article field mappings were not coerced to null in the rpk model
- Fixed issue with google drive configuration missing the "additionalProperties" setting
- Fixed issue with multiple array models where length constraints incorrectly specified with minLength/maxLength rather than minItems/maxItems
