### PR TITLE
Add support for create/update/delete SharePoint 2013/2016 data source.

### DIFF
--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -215,7 +215,9 @@
         "SharePointVersion": {
           "type": "string",
           "enum": [
-            "SHAREPOINT_ONLINE"
+            "SHAREPOINT_ONLINE",
+            "SHAREPOINT_2013",
+            "SHAREPOINT_2016"
           ]
         },
         "Urls": {
@@ -251,6 +253,9 @@
         },
         "DisableLocalGroups": {
           "$ref": "#/definitions/DisableLocalGroups"
+        },
+        "SslCertificateS3Path": {
+          "$ref": "#/definitions/S3Path"
         }
       },
       "additionalProperties": false,

--- a/aws-kendra-datasource/pom.xml
+++ b/aws-kendra-datasource/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kendra</artifactId>
-            <version>2.16.104</version>
+            <version>2.17.22</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/S3PathConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/S3PathConverter.java
@@ -1,0 +1,28 @@
+package software.amazon.kendra.datasource.convert;
+
+import software.amazon.kendra.datasource.S3Path;
+
+public class S3PathConverter {
+
+    static software.amazon.awssdk.services.kendra.model.S3Path toSdk(S3Path model) {
+        if (model == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.kendra.model.S3Path
+                .builder()
+                .bucket(model.getBucket())
+                .key(model.getKey())
+                .build();
+    }
+
+    static S3Path toModel(software.amazon.awssdk.services.kendra.model.S3Path sdk) {
+        if (sdk == null) {
+            return null;
+        }
+        return S3Path
+                .builder()
+                .bucket(sdk.bucket())
+                .key(sdk.key())
+                .build();
+    }
+}

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/SharePointConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/SharePointConverter.java
@@ -22,6 +22,7 @@ public class SharePointConverter {
             .fieldMappings(ListConverter.toSdk(model.getFieldMappings(), FieldMappingConverter::toSdk))
             .documentTitleFieldName(model.getDocumentTitleFieldName())
             .disableLocalGroups(model.getDisableLocalGroups())
+            .sslCertificateS3Path(S3PathConverter.toSdk(model.getSslCertificateS3Path()))
             .build();
   }
 
@@ -48,6 +49,7 @@ public class SharePointConverter {
             .fieldMappings(ListConverter.toModel(sdk.fieldMappings(), FieldMappingConverter::toModel))
             .documentTitleFieldName(sdk.documentTitleFieldName())
             .disableLocalGroups(sdk.disableLocalGroups())
+            .sslCertificateS3Path(S3PathConverter.toModel(sdk.sslCertificateS3Path()))
             .build();
   }
 

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/S3PathConverterTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/S3PathConverterTest.java
@@ -1,0 +1,51 @@
+package software.amazon.kendra.datasource.convert;
+
+import org.junit.jupiter.api.Test;
+
+import software.amazon.kendra.datasource.S3Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class S3PathConverterTest {
+
+    @Test
+    void testToSdkOneDriveUsers() {
+        String bucket = "bucket";
+        String key = "key";
+        S3Path modelS3Path = S3Path
+                .builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        software.amazon.awssdk.services.kendra.model.S3Path sdk =
+                software.amazon.awssdk.services.kendra.model.S3Path
+                                        .builder()
+                                        .bucket(bucket)
+                                        .key(key)
+                                        .build();
+
+        assertThat(S3PathConverter.toSdk(modelS3Path)).isEqualTo(sdk);
+    }
+
+    @Test
+    void testToModelOneDriveUsers() {
+        String bucket = "bucket";
+        String key = "key";
+
+        software.amazon.awssdk.services.kendra.model.S3Path sdk =
+                software.amazon.awssdk.services.kendra.model.S3Path
+                        .builder()
+                        .bucket(bucket)
+                        .key(key)
+                        .build();
+
+        S3Path modelS3Path = S3Path
+                .builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        assertThat(S3PathConverter.toModel(sdk)).isEqualTo(modelS3Path);
+    }
+}

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/SharePointConverterTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/SharePointConverterTest.java
@@ -1,11 +1,9 @@
 package software.amazon.kendra.datasource.convert;
 
 import org.junit.jupiter.api.Test;
+
 import software.amazon.awssdk.services.kendra.model.SharePointVersion;
-import software.amazon.kendra.datasource.DataSourceConfiguration;
-import software.amazon.kendra.datasource.DataSourceToIndexFieldMapping;
-import software.amazon.kendra.datasource.DataSourceVpcConfiguration;
-import software.amazon.kendra.datasource.SharePointConfiguration;
+import software.amazon.kendra.datasource.*;
 
 import java.util.Arrays;
 
@@ -65,6 +63,124 @@ public class SharePointConverterTest {
   }
 
   @Test
+  public void testSdkDataSourceConfiguration_2013() {
+    DataSourceConfiguration dataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .disableLocalGroups(true)
+                    .fieldMappings(Arrays.asList(DataSourceToIndexFieldMapping.builder()
+                            .dataSourceFieldName("testDataSourceFieldName")
+                            .dateFieldFormat("testDateFieldFormat")
+                            .indexFieldName("testIndexFieldName")
+                            .build()))
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .sslCertificateS3Path(S3Path.builder()
+                            .bucket("bucket")
+                            .key("key")
+                            .build())
+                    .build())
+            .build();
+
+    software.amazon.awssdk.services.kendra.model.SharePointConfiguration expectedDataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .fieldMappings(Arrays.asList(software.amazon.awssdk.services.kendra.model.DataSourceToIndexFieldMapping.builder()
+                            .dataSourceFieldName("testDataSourceFieldName")
+                            .dateFieldFormat("testDateFieldFormat")
+                            .indexFieldName("testIndexFieldName")
+                            .build()))
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .disableLocalGroups(true)
+                    .sslCertificateS3Path(software.amazon.awssdk.services.kendra.model.S3Path.builder()
+                            .bucket("bucket")
+                            .key("key")
+                            .build())
+                    .build();
+
+    assertThat(SharePointConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getSharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
+
+  @Test
+  public void testSdkDataSourceConfiguration_2016() {
+    DataSourceConfiguration dataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .disableLocalGroups(true)
+                    .fieldMappings(Arrays.asList(DataSourceToIndexFieldMapping.builder()
+                            .dataSourceFieldName("testDataSourceFieldName")
+                            .dateFieldFormat("testDateFieldFormat")
+                            .indexFieldName("testIndexFieldName")
+                            .build()))
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .sslCertificateS3Path(S3Path.builder()
+                            .bucket("bucket")
+                            .key("key")
+                            .build())
+                    .build())
+            .build();
+
+    software.amazon.awssdk.services.kendra.model.SharePointConfiguration expectedDataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .fieldMappings(Arrays.asList(software.amazon.awssdk.services.kendra.model.DataSourceToIndexFieldMapping.builder()
+                            .dataSourceFieldName("testDataSourceFieldName")
+                            .dateFieldFormat("testDateFieldFormat")
+                            .indexFieldName("testIndexFieldName")
+                            .build()))
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .disableLocalGroups(true)
+                    .sslCertificateS3Path(software.amazon.awssdk.services.kendra.model.S3Path.builder()
+                            .bucket("bucket")
+                            .key("key")
+                            .build())
+                    .build();
+
+    assertThat(SharePointConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getSharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
+
+  @Test
   public void testSdkDataSourceConfiguration_withNullVpcConfigurationAndNullFieldMappings() {
     DataSourceConfiguration dataSourceConfiguration = DataSourceConfiguration.builder()
       .sharePointConfiguration(SharePointConfiguration.builder()
@@ -91,6 +207,88 @@ public class SharePointConverterTest {
                     .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
                     .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
                     .documentTitleFieldName("testDocumentTitleFieldName")
+                    .build();
+
+    assertThat(SharePointConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getSharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
+
+  @Test
+  public void testSdkDataSourceConfiguration2013_withNullSslCertAndNullFieldMappings() {
+    DataSourceConfiguration dataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .disableLocalGroups(true)
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .build())
+            .build();
+
+    software.amazon.awssdk.services.kendra.model.SharePointConfiguration expectedDataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .disableLocalGroups(true)
+                    .build();
+
+    assertThat(SharePointConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getSharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
+
+  @Test
+  public void testSdkDataSourceConfiguration2016_withNullSslCertAndNullFieldMappings() {
+    DataSourceConfiguration dataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .disableLocalGroups(true)
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .build())
+            .build();
+
+    software.amazon.awssdk.services.kendra.model.SharePointConfiguration expectedDataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                    .urls(Arrays.asList("http://www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .disableLocalGroups(true)
                     .build();
 
     assertThat(SharePointConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getSharePointConfiguration()))
@@ -151,6 +349,128 @@ public class SharePointConverterTest {
   }
 
   @Test
+  public void testModelDataSourceConfiguration_2013() {
+    software.amazon.awssdk.services.kendra.model.DataSourceConfiguration dataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder()
+                    .sharePointConfiguration(software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                            .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                            .urls(Arrays.asList("www.sharepoint.com"))
+                            .secretArn("secretArn")
+                            .crawlAttachments(true)
+                            .useChangeLog(true)
+                            .disableLocalGroups(true)
+                            .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                            .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                            .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                                    .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                                    .subnetIds(Arrays.asList("testSubnetId"))
+                                    .build())
+                            .fieldMappings(Arrays.asList(software.amazon.awssdk.services.kendra.model.DataSourceToIndexFieldMapping.builder()
+                                    .dataSourceFieldName("testDataSourceFieldName")
+                                    .dateFieldFormat("testDateFieldFormat")
+                                    .indexFieldName("testIndexFieldName")
+                                    .build()))
+                            .documentTitleFieldName("testDocumentTitleFieldName")
+                            .sslCertificateS3Path(software.amazon.awssdk.services.kendra.model.S3Path.builder()
+                                    .bucket("bucket")
+                                    .key("key")
+                                    .build())
+                            .build())
+                    .build();
+
+    DataSourceConfiguration expectedDataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                    .urls(Arrays.asList("www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .disableLocalGroups(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .fieldMappings(Arrays.asList(DataSourceToIndexFieldMapping.builder()
+                            .dataSourceFieldName("testDataSourceFieldName")
+                            .dateFieldFormat("testDateFieldFormat")
+                            .indexFieldName("testIndexFieldName")
+                            .build()))
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .sslCertificateS3Path(S3Path.builder()
+                            .bucket("bucket")
+                            .key("key")
+                            .build())
+                    .build())
+            .build();
+
+    assertThat(SharePointConverter.toModelDataSourceConfiguration(dataSourceConfiguration.sharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
+
+  @Test
+  public void testModelDataSourceConfiguration_2016() {
+    software.amazon.awssdk.services.kendra.model.DataSourceConfiguration dataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder()
+                    .sharePointConfiguration(software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                            .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                            .urls(Arrays.asList("www.sharepoint.com"))
+                            .secretArn("secretArn")
+                            .crawlAttachments(true)
+                            .useChangeLog(true)
+                            .disableLocalGroups(true)
+                            .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                            .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                            .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                                    .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                                    .subnetIds(Arrays.asList("testSubnetId"))
+                                    .build())
+                            .fieldMappings(Arrays.asList(software.amazon.awssdk.services.kendra.model.DataSourceToIndexFieldMapping.builder()
+                                    .dataSourceFieldName("testDataSourceFieldName")
+                                    .dateFieldFormat("testDateFieldFormat")
+                                    .indexFieldName("testIndexFieldName")
+                                    .build()))
+                            .documentTitleFieldName("testDocumentTitleFieldName")
+                            .sslCertificateS3Path(software.amazon.awssdk.services.kendra.model.S3Path.builder()
+                                    .bucket("bucket")
+                                    .key("key")
+                                    .build())
+                            .build())
+                    .build();
+
+    DataSourceConfiguration expectedDataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                    .urls(Arrays.asList("www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .disableLocalGroups(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .fieldMappings(Arrays.asList(DataSourceToIndexFieldMapping.builder()
+                            .dataSourceFieldName("testDataSourceFieldName")
+                            .dateFieldFormat("testDateFieldFormat")
+                            .indexFieldName("testIndexFieldName")
+                            .build()))
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .sslCertificateS3Path(S3Path.builder()
+                            .bucket("bucket")
+                            .key("key")
+                            .build())
+                    .build())
+            .build();
+
+    assertThat(SharePointConverter.toModelDataSourceConfiguration(dataSourceConfiguration.sharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
+
+  @Test
   public void testModelDataSourceConfiguration_withNullVpcConfigurationAndNullFieldMappings() {
     software.amazon.awssdk.services.kendra.model.DataSourceConfiguration dataSourceConfiguration =
       software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder()
@@ -183,4 +503,85 @@ public class SharePointConverterTest {
     .isEqualTo(expectedDataSourceConfiguration);
   }
 
+  @Test
+  public void testModelDataSourceConfiguration2013_withNullSslCertAndNullFieldMappings() {
+    software.amazon.awssdk.services.kendra.model.DataSourceConfiguration dataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder()
+                    .sharePointConfiguration(software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                            .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                            .urls(Arrays.asList("www.sharepoint.com"))
+                            .secretArn("secretArn")
+                            .crawlAttachments(true)
+                            .useChangeLog(true)
+                            .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                            .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                            .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                                    .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                                    .subnetIds(Arrays.asList("testSubnetId"))
+                                    .build())
+                            .documentTitleFieldName("testDocumentTitleFieldName")
+                            .build())
+                    .build();
+
+    DataSourceConfiguration expectedDataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2013.toString())
+                    .urls(Arrays.asList("www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .build())
+            .build();
+
+    assertThat(SharePointConverter.toModelDataSourceConfiguration(dataSourceConfiguration.sharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
+
+  @Test
+  public void testModelDataSourceConfiguration2016_withNullSslCertAndNullFieldMappings() {
+    software.amazon.awssdk.services.kendra.model.DataSourceConfiguration dataSourceConfiguration =
+            software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder()
+                    .sharePointConfiguration(software.amazon.awssdk.services.kendra.model.SharePointConfiguration.builder()
+                            .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                            .urls(Arrays.asList("www.sharepoint.com"))
+                            .secretArn("secretArn")
+                            .crawlAttachments(true)
+                            .useChangeLog(true)
+                            .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                            .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                            .vpcConfiguration( software.amazon.awssdk.services.kendra.model.DataSourceVpcConfiguration.builder()
+                                    .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                                    .subnetIds(Arrays.asList("testSubnetId"))
+                                    .build())
+                            .documentTitleFieldName("testDocumentTitleFieldName")
+                            .build())
+                    .build();
+
+    DataSourceConfiguration expectedDataSourceConfiguration = DataSourceConfiguration.builder()
+            .sharePointConfiguration(SharePointConfiguration.builder()
+                    .sharePointVersion(SharePointVersion.SHAREPOINT_2016.toString())
+                    .urls(Arrays.asList("www.sharepoint.com"))
+                    .secretArn("secretArn")
+                    .crawlAttachments(true)
+                    .useChangeLog(true)
+                    .inclusionPatterns(Arrays.asList("testInclusionPatterns"))
+                    .exclusionPatterns(Arrays.asList("testExclusionPatterns"))
+                    .vpcConfiguration( DataSourceVpcConfiguration.builder()
+                            .securityGroupIds(Arrays.asList("testSecurityGroupId"))
+                            .subnetIds(Arrays.asList("testSubnetId"))
+                            .build())
+                    .documentTitleFieldName("testDocumentTitleFieldName")
+                    .build())
+            .build();
+
+    assertThat(SharePointConverter.toModelDataSourceConfiguration(dataSourceConfiguration.sharePointConfiguration()))
+            .isEqualTo(expectedDataSourceConfiguration);
+  }
 }

--- a/aws-kendra-faq/pom.xml
+++ b/aws-kendra-faq/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kendra</artifactId>
-            <version>2.16.104</version>
+            <version>2.17.22</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>

--- a/aws-kendra-index/pom.xml
+++ b/aws-kendra-index/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>kendra</artifactId>
-            <version>2.16.104</version>
+            <version>2.17.22</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/software.amazon.cloudformation/aws-cloudformation-rpdk-java-plugin -->
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add support for SharePoint 2013/2016 version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
