### PR TITLE
Fix an invalid model syntax in WebCrawler that cause runtime failure.

### DIFF
--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -1328,7 +1328,7 @@
         },
         "MaxContentSizePerPageInMegaBytes": {
           "type": "number",
-          "minimum": 0.000001,
+          "minimum": 0,
           "maximum": 50
         },
         "MaxUrlsPerMinuteCrawlRate": {


### PR DESCRIPTION
*Issue #, if available:*
Fix an invalid property, change "minimum" from 0.000001 to 0. Apparently previous value is invalid and will fail silently at runtime of creating stack. Change it to zero that Kendra will throw exception if input is below minimum value.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
