### PR TITLE
Fixed WebCrawler Host Mode Missing

### DIFF
--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/WebCrawlerConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/WebCrawlerConverter.java
@@ -70,7 +70,7 @@ public class WebCrawlerConverter {
 
         return WebCrawlerSeedUrlConfiguration.builder()
             .seedUrls(StringListConverter.toModel(sdk.seedUrls()))
-            .webCrawlerMode(sdk.webCrawlerMode().toString())
+            .webCrawlerMode(sdk.webCrawlerModeAsString())
             .build();
     }
 

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/webcrawler/WebCrawlerConverterTestCases.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/webcrawler/WebCrawlerConverterTestCases.java
@@ -7,6 +7,8 @@ import software.amazon.awssdk.services.kendra.model.SeedUrlConfiguration;
 import software.amazon.awssdk.services.kendra.model.SiteMapsConfiguration;
 import software.amazon.awssdk.services.kendra.model.Urls;
 import software.amazon.awssdk.services.kendra.model.WebCrawlerConfiguration;
+import software.amazon.kendra.datasource.WebCrawlerSeedUrlConfiguration;
+import software.amazon.kendra.datasource.WebCrawlerUrls;
 
 import java.util.Arrays;
 
@@ -257,7 +259,61 @@ public class WebCrawlerConverterTestCases {
                             .build())
                     .build()
             ))
-            .build()
+            .build(),
+
+        WebCrawlerConverterTestCase.builder()
+            .description("Failing test case - invalid")
+            .isSymmetrical(false)
+            .input(new WebCrawlerConverterTestCase.ModelData(
+                software.amazon.kendra.datasource.WebCrawlerConfiguration.builder()
+                    .crawlDepth(10)
+                    .urls(WebCrawlerUrls.builder()
+                        .seedUrlConfiguration(WebCrawlerSeedUrlConfiguration.builder()
+                            .seedUrls(Arrays.asList("https://www.amazon.com"))
+                            .webCrawlerMode("This is some value that isn't valid by our API but our converter will handle")
+                            .build())
+                        .build())
+                    .build()
+            ))
+            .expectedOutput(new WebCrawlerConverterTestCase.SdkData(
+                WebCrawlerConfiguration.builder()
+                    .crawlDepth(10)
+                    .urls(Urls.builder()
+                        .seedUrlConfiguration(SeedUrlConfiguration.builder()
+                            .seedUrls("https://www.amazon.com")
+                            .webCrawlerMode("This is some value that isn't valid by our API but our converter will handle")
+                            .build())
+                        .build())
+                    .build()
+            ))
+            .build(),
+
+        WebCrawlerConverterTestCase.builder()
+            .description("Failing test case - null web crawler mode")
+            .isSymmetrical(false)
+            .input(new WebCrawlerConverterTestCase.ModelData(
+                software.amazon.kendra.datasource.WebCrawlerConfiguration.builder()
+                    .crawlDepth(10)
+                    .urls(WebCrawlerUrls.builder()
+                        .seedUrlConfiguration(WebCrawlerSeedUrlConfiguration.builder()
+                            .seedUrls(Arrays.asList("https://www.amazon.com"))
+                            .webCrawlerMode(null)
+                            .build())
+                        .build())
+                    .build()
+            ))
+            .expectedOutput(new WebCrawlerConverterTestCase.SdkData(
+                WebCrawlerConfiguration.builder()
+                    .crawlDepth(10)
+                    .urls(Urls.builder()
+                        .seedUrlConfiguration(SeedUrlConfiguration.builder()
+                            .seedUrls("https://www.amazon.com")
+                            .webCrawlerMode((String) null)
+                            .build())
+                        .build())
+                    .build()
+            ))
+            .build(),
     };
 
     private WebCrawlerConverterTestCases() {


### PR DESCRIPTION
**Problem**

If web crawler mode is null this causes a NPE in the handler

**Solution**

Use the `.webCrawlerModeAsString()` method to not de-reference null

**Does this commit contain any backward incompatible changes?**

no

**Does this commit depend on another service which needs to be deployed first?**

no

**Does this commit emit a new cloudwatch metric or cloudwatch log in Customer account?**

no

**Have you added Integ test – Y/N?**

no, tested manually

**Have you added Canary test – Y/N?**
no

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
