### PR TITLE
BugFix: cloudformatin stack updates always fail if the current templa…

### DIFF
--- a/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
+++ b/aws-kendra-index/src/main/java/software/amazon/kendra/index/Translator.java
@@ -219,7 +219,12 @@ public class Translator {
 
     Map<String, String> previousMetadataNames = new HashMap<>();
     if (prev != null && !prev.isEmpty()) {
-      previousMetadataNames = prev.stream().collect(Collectors.toMap(x -> x.getName(), x -> x.getType()));
+      // duplicated config name is not checked, so some cloudformation template might contain duplicated names
+      // use for loop instead of stream since collect to map does not support duplicated key. This prevents
+      // any updates for the existing cloudformation templates that has duplicated keys
+      for (software.amazon.kendra.index.DocumentMetadataConfiguration documentMetadataConfiguration : prev) {
+        previousMetadataNames.put(documentMetadataConfiguration.getName(), documentMetadataConfiguration.getType());
+      }
     }
     Set<String> currMetadataNames = new HashSet<>();
     if (curr != null && !curr.isEmpty()) {


### PR DESCRIPTION
…te contains duplicated name in the index document metadata configurations.

*Issue #, if available:*
NA

*Description of changes:*
If a Kendra index was created with document metadata configuration that contains duplicated configuration names, any subsequent updates to this stack will fail. The reason is that Stream().map will throw exceptions when there are duplicated keys. Update to use simple for loop and just pick the last configure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
