### PR TITLE
Update DataSource Handlers to map underlying Kendra API errors to Cloudformation exceptions

### DIFF
--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ApiName.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ApiName.java
@@ -5,5 +5,6 @@ public class ApiName {
     static final String UPDATE_DATASOURCE = "UpdateDataSource";
     static final String DESCRIBE_DATASOURCE = "DescribeDataSource";
     static final String DELETE_DATASOURCE = "DeleteDataSource";
+    static final String LIST_DATA_SOURCES = "ListDataSources";
     static final String LIST_TAGS_FOR_RESOURCE = "ListTagsForResource";
 }

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/DeleteHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/DeleteHandler.java
@@ -2,14 +2,20 @@ package software.amazon.kendra.datasource;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.kendra.KendraClient;
+import software.amazon.awssdk.services.kendra.model.AccessDeniedException;
 import software.amazon.awssdk.services.kendra.model.ConflictException;
 import software.amazon.awssdk.services.kendra.model.DeleteDataSourceRequest;
 import software.amazon.awssdk.services.kendra.model.DeleteDataSourceResponse;
 import software.amazon.awssdk.services.kendra.model.DescribeDataSourceRequest;
 import software.amazon.awssdk.services.kendra.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kendra.model.ThrottlingException;
+import software.amazon.awssdk.services.kendra.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Delay;
 import software.amazon.cloudformation.proxy.Logger;
@@ -35,7 +41,7 @@ public class DeleteHandler extends BaseHandlerStd {
 
     private Logger logger;
 
-    private Delay delay;
+    private final Delay delay;
 
     public DeleteHandler() {
         super();
@@ -105,6 +111,12 @@ public class DeleteHandler extends BaseHandlerStd {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, deleteDataSourceRequest.id(), e);
         } catch (ConflictException e) {
             throw new CfnResourceConflictException(e);
+        } catch (AccessDeniedException e) {
+            throw new CfnAccessDeniedException(DELETE_DATASOURCE, e);
+        } catch (ValidationException e) {
+            throw new CfnInvalidRequestException(e);
+        } catch (ThrottlingException e) {
+            throw new CfnThrottlingException(DELETE_DATASOURCE, e);
         } catch (final AwsServiceException e) {
             /*
              * While the handler contract states that the handler must always return a progress event,

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ListHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/ListHandler.java
@@ -1,8 +1,20 @@
 package software.amazon.kendra.datasource;
 
+import static software.amazon.kendra.datasource.ApiName.LIST_DATA_SOURCES;
+
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.kendra.KendraClient;
+import software.amazon.awssdk.services.kendra.model.AccessDeniedException;
 import software.amazon.awssdk.services.kendra.model.ListDataSourcesRequest;
 import software.amazon.awssdk.services.kendra.model.ListDataSourcesResponse;
+import software.amazon.awssdk.services.kendra.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kendra.model.ThrottlingException;
+import software.amazon.awssdk.services.kendra.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
+import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -25,7 +37,7 @@ public class ListHandler extends BaseHandlerStd {
         final ListDataSourcesRequest listDataSourcesRequest = Translator.translateToListRequest(
             indexId,request.getNextToken());
 
-        ListDataSourcesResponse listDataSourcesResponse = proxy.injectCredentialsAndInvokeV2(listDataSourcesRequest, proxyClient.client()::listDataSources);
+        ListDataSourcesResponse listDataSourcesResponse = listDataSources(listDataSourcesRequest, proxyClient);
 
         String nextToken = listDataSourcesResponse.nextToken();
 
@@ -34,5 +46,23 @@ public class ListHandler extends BaseHandlerStd {
             .nextToken(nextToken)
             .status(OperationStatus.SUCCESS)
             .build();
+    }
+
+    private ListDataSourcesResponse listDataSources(
+        ListDataSourcesRequest request,
+        ProxyClient<KendraClient> proxyClient) {
+        try {
+            return proxyClient.injectCredentialsAndInvokeV2(request, proxyClient.client()::listDataSources);
+        } catch (ValidationException e) {
+            throw new CfnInvalidRequestException(e);
+        } catch (ResourceNotFoundException e) {
+            throw new CfnNotFoundException(e);
+        } catch (AccessDeniedException e) {
+            throw new CfnAccessDeniedException(LIST_DATA_SOURCES, e);
+        } catch (ThrottlingException e) {
+            throw new CfnThrottlingException(LIST_DATA_SOURCES, e);
+        } catch (final AwsServiceException e) {
+            throw new CfnGeneralServiceException(LIST_DATA_SOURCES, e);
+        }
     }
 }

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/UpdateHandler.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/UpdateHandler.java
@@ -3,21 +3,27 @@ package software.amazon.kendra.datasource;
 import com.google.common.collect.Sets;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.kendra.KendraClient;
+import software.amazon.awssdk.services.kendra.model.AccessDeniedException;
 import software.amazon.awssdk.services.kendra.model.ConflictException;
 import software.amazon.awssdk.services.kendra.model.DataSourceStatus;
 import software.amazon.awssdk.services.kendra.model.DescribeDataSourceRequest;
 import software.amazon.awssdk.services.kendra.model.DescribeDataSourceResponse;
 import software.amazon.awssdk.services.kendra.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kendra.model.ServiceQuotaExceededException;
 import software.amazon.awssdk.services.kendra.model.TagResourceRequest;
+import software.amazon.awssdk.services.kendra.model.ThrottlingException;
 import software.amazon.awssdk.services.kendra.model.UntagResourceRequest;
 import software.amazon.awssdk.services.kendra.model.UpdateDataSourceRequest;
 import software.amazon.awssdk.services.kendra.model.UpdateDataSourceResponse;
 import software.amazon.awssdk.services.kendra.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
 import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.exceptions.CfnNotFoundException;
 import software.amazon.cloudformation.exceptions.CfnNotUpdatableException;
 import software.amazon.cloudformation.exceptions.CfnResourceConflictException;
+import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -35,7 +41,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
     private Logger logger;
 
-    private DataSourceArnBuilder dataSourceArnBuilder;
+    private final DataSourceArnBuilder dataSourceArnBuilder;
 
     public UpdateHandler() {
        super();
@@ -106,6 +112,12 @@ public class UpdateHandler extends BaseHandlerStd {
             throw new CfnNotFoundException(ResourceModel.TYPE_NAME, updateDataSourceRequest.id(), e);
         } catch (ConflictException e) {
             throw new CfnResourceConflictException(e);
+        } catch (ServiceQuotaExceededException e) {
+            throw new CfnServiceLimitExceededException(ResourceModel.TYPE_NAME, e.getMessage(), e);
+        } catch (AccessDeniedException e) {
+            throw new CfnAccessDeniedException(UPDATE_DATASOURCE, e);
+        } catch (ThrottlingException e) {
+            throw new CfnThrottlingException(UPDATE_DATASOURCE, e);
         } catch (final AwsServiceException e) {
            /*
             * While the handler contract states that the handler must always return a progress event,

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/ListHandlerTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/ListHandlerTest.java
@@ -1,10 +1,19 @@
 package software.amazon.kendra.datasource;
 
 import org.junit.jupiter.api.AfterEach;
+
 import software.amazon.awssdk.services.kendra.KendraClient;
-import software.amazon.awssdk.services.kendra.model.DataSourceSummary;
+import software.amazon.awssdk.services.kendra.model.AccessDeniedException;
+import software.amazon.awssdk.services.kendra.model.KendraException;
 import software.amazon.awssdk.services.kendra.model.ListDataSourcesRequest;
 import software.amazon.awssdk.services.kendra.model.ListDataSourcesResponse;
+import software.amazon.awssdk.services.kendra.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kendra.model.ThrottlingException;
+import software.amazon.awssdk.services.kendra.model.ValidationException;
+import software.amazon.cloudformation.exceptions.CfnAccessDeniedException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import software.amazon.cloudformation.exceptions.CfnNotFoundException;
+import software.amazon.cloudformation.exceptions.CfnThrottlingException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -13,15 +22,18 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -50,8 +62,6 @@ public class ListHandlerTest extends AbstractTestBase {
         proxy = new AmazonWebServicesClientProxy(logger, MOCK_CREDENTIALS, () -> Duration.ofSeconds(600).toMillis());
         sdkClient = mock(KendraClient.class);
         proxyClient = MOCK_PROXY(proxy, sdkClient);
-                when(proxyClient.client().listDataSources(any(ListDataSourcesRequest.class)))
-                .thenReturn(ListDataSourcesResponse.builder().summaryItems(new ArrayList<>()).build());
     }
 
     @AfterEach
@@ -67,15 +77,12 @@ public class ListHandlerTest extends AbstractTestBase {
             .id(TEST_ID)
             .indexId(TEST_INDEX_ID)
             .build();
+        when(proxyClient.client().listDataSources(any(ListDataSourcesRequest.class)))
+            .thenReturn(ListDataSourcesResponse.builder().summaryItems(new ArrayList<>()).build());
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
             .build();
-
-        List<DataSourceSummary> dataSourceSummaryList =
-            Arrays.asList(DataSourceSummary.builder()
-                .id(TEST_ID)
-                .build());
 
         final ProgressEvent<ResourceModel, CallbackContext> response =
             handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
@@ -89,6 +96,39 @@ public class ListHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
+        verify(proxyClient.client(), times(1)).listDataSources(any(ListDataSourcesRequest.class));
+    }
+
+    static Stream<Arguments> kendraErrorExpectedCfnErrorArguments() {
+        return Stream.of(
+          Arguments.of(ValidationException.builder().build(), CfnInvalidRequestException.class),
+          Arguments.of(ResourceNotFoundException.builder().build(), CfnNotFoundException.class),
+          Arguments.of(AccessDeniedException.builder().build(), CfnAccessDeniedException.class),
+          Arguments.of(ThrottlingException.builder().build(), CfnThrottlingException.class)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("kendraErrorExpectedCfnErrorArguments")
+    public void testItThrowsMappedCfnErrorForKendraError(
+        KendraException kendraException,
+        Class<? extends RuntimeException> expectedCfnError) {
+        // set up test scenario
+        final ListHandler handler = new ListHandler();
+
+        final ResourceModel model = ResourceModel.builder()
+            .id(TEST_ID)
+            .indexId(TEST_INDEX_ID)
+            .build();
+        when(proxyClient.client().listDataSources(any(ListDataSourcesRequest.class)))
+            .thenThrow(kendraException);
+
+        // make request and verify error
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .desiredResourceState(model)
+            .build();
+        assertThatThrownBy(() -> handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger))
+            .isInstanceOf(expectedCfnError);
         verify(proxyClient.client(), times(1)).listDataSources(any(ListDataSourcesRequest.class));
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

See https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kendra/pull/105 for motivation for making this PR.

Similar to: https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kendra/pull/102, this PR updates DataSource Handlers to map Kendra Exceptions to equivalent CFN errors to improve clarity when CFN failures occur.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
