### PR TITLE
Add support for "LanguageCode" to Kendra Datasource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The CloudFormation Resource Provider Package For AWS Kendra.
 
+[![Maven Verify Pipeline](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kendra/actions/workflows/maven-verify.yml/badge.svg?branch=master)](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kendra/actions/workflows/maven-verify.yml)
+
 ## License
 
 This project is licensed under the Apache-2.0 License.

--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -1522,6 +1522,13 @@
       "minLength": 1,
       "maxLength": 1000
     },
+    "LanguageCode": {
+      "description": "The code for a language.",
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 10,
+      "pattern": "[a-zA-Z-]*"
+    },
     "RoleArn": {
       "description": "Role ARN",
       "type": "string",
@@ -1733,6 +1740,9 @@
     },
     "CustomDocumentEnrichmentConfiguration": {
       "$ref": "#/definitions/CustomDocumentEnrichmentConfiguration"
+    },
+    "LanguageCode": {
+      "$ref": "#/definitions/LanguageCode"
     }
   },
   "required": [

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
@@ -58,6 +58,7 @@ public class Translator {
             .description(model.getDescription())
             .schedule(model.getSchedule())
             .roleArn(model.getRoleArn())
+            .languageCode(model.getLanguageCode())
             .customDocumentEnrichmentConfiguration(CustomDocumentEnrichmentConfigurationConverter
                     .toSdkCustomDocumentEnrichmentConfiguration(model.getCustomDocumentEnrichmentConfiguration()));
     if (model.getTags() != null && !model.getTags().isEmpty()) {
@@ -99,6 +100,7 @@ public class Translator {
             .roleArn(describeDataSourceResponse.roleArn())
             .schedule(describeDataSourceResponse.schedule())
             .type(describeDataSourceResponse.typeAsString())
+            .languageCode(describeDataSourceResponse.languageCode())
             .dataSourceConfiguration(toModelDataSourceConfiguration(describeDataSourceResponse.configuration(),
                     describeDataSourceResponse.typeAsString()))
             .customDocumentEnrichmentConfiguration(CustomDocumentEnrichmentConfigurationConverter
@@ -139,6 +141,7 @@ public class Translator {
             .indexId(model.getIndexId())
             .roleArn(roleArn)
             .name(name)
+            .languageCode(model.getLanguageCode())
             .description(description)
             .configuration(dataSourceConfiguration)
             .schedule(schedule)

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/TranslatorTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/TranslatorTest.java
@@ -142,7 +142,25 @@ public class TranslatorTest {
         assertThat(createDataSourceRequest.indexId()).isEqualTo(indexId);
         assertThat(createDataSourceRequest.tags().size()).isEqualTo(1);
         assertThat(createDataSourceRequest.tags().get(0).key()).isEqualTo("key");
+        assertThat(createDataSourceRequest.languageCode()).isNull();
         assertThat(createDataSourceRequest.tags().get(0).value()).isEqualTo("value");
+    }
+
+    @Test
+    void testTranslateToCreateRequest_WithLanguageCode() {
+        String indexId = "indexId";
+        ResourceModel resourceModel = ResourceModel
+            .builder()
+            .indexId(indexId)
+            .tags(Arrays.asList(Tag.builder().key("key").value("value").build()))
+            .languageCode("de")
+            .build();
+        CreateDataSourceRequest createDataSourceRequest = Translator.translateToCreateRequest(resourceModel);
+        assertThat(createDataSourceRequest.indexId()).isEqualTo(indexId);
+        assertThat(createDataSourceRequest.tags().size()).isEqualTo(1);
+        assertThat(createDataSourceRequest.tags().get(0).key()).isEqualTo("key");
+        assertThat(createDataSourceRequest.tags().get(0).value()).isEqualTo("value");
+        assertThat(createDataSourceRequest.languageCode()).isEqualTo("de");
     }
 
     @Test
@@ -153,6 +171,7 @@ public class TranslatorTest {
                 .builder()
                 .id(id)
                 .indexId(indexId)
+                .languageCode("de")
                 .description("description")
                 .build();
         UpdateDataSourceRequest updateDataSourceRequest = Translator.translateToUpdateRequest(resourceModel);
@@ -162,6 +181,7 @@ public class TranslatorTest {
         assertThat(updateDataSourceRequest.name()).isEqualTo(null);
         assertThat(updateDataSourceRequest.roleArn()).isEqualTo(null);
         assertThat(updateDataSourceRequest.schedule()).isEqualTo(null);
+        assertThat(updateDataSourceRequest.languageCode()).isEqualTo("de");
         assertThat(updateDataSourceRequest.configuration())
                 .isEqualTo(null);
     }
@@ -182,6 +202,7 @@ public class TranslatorTest {
         assertThat(updateDataSourceRequest.name()).isEqualTo(null);
         assertThat(updateDataSourceRequest.roleArn()).isEqualTo(null);
         assertThat(updateDataSourceRequest.schedule()).isEqualTo(null);
+        assertThat(updateDataSourceRequest.languageCode()).isNull();
         assertThat(updateDataSourceRequest.configuration())
                 .isEqualTo(null);
     }


### PR DESCRIPTION
*Issue #, if available:*
Fixes #97

*Description of changes:*

Adds support for LanguageCode to **AWS::Kendra::DataSource**.

Here is the configuration field in the [Kendra DataSource API docs](https://docs.aws.amazon.com/kendra/latest/APIReference/API_CreateDataSource.html#kendra-CreateDataSource-request-LanguageCode).

```
[LanguageCode](https://docs.aws.amazon.com/kendra/latest/APIReference/API_CreateDataSource.html#API_CreateDataSource_RequestSyntax)

    The code for a language. This allows you to support a language for all documents when creating the data source connector. English is supported by default. For more information on supported languages, including their codes, see [Adding documents in languages other than English](https://docs.aws.amazon.com/kendra/latest/dg/in-adding-languages.html).

    Type: String

    Length Constraints: Minimum length of 2. Maximum length of 10.

    Pattern: [a-zA-Z-]*

    Required: No
```

-----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
