### PR TITLE
[WIP] feat: support template configuration

### DIFF
--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -1388,7 +1388,7 @@
       "type": "object",
       "properties": {
         "Template": {
-          "type": "string"
+          "type": "object"
         }
       },
       "additionalProperties": false,

--- a/aws-kendra-datasource/aws-kendra-datasource.json
+++ b/aws-kendra-datasource/aws-kendra-datasource.json
@@ -1384,6 +1384,18 @@
         "OrganizationId"
       ]
     },
+    "TemplateConfiguration": {
+      "type": "object",
+      "properties": {
+        "Template": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "Template"
+      ]
+    },
     "DataSourceConfiguration": {
       "type": "object",
       "properties": {
@@ -1416,6 +1428,9 @@
         },
         "WorkDocsConfiguration": {
           "$ref": "#/definitions/WorkDocsConfiguration"
+        },
+        "TemplateConfiguration": {
+          "$ref": "#/definitions/TemplateConfiguration"
         }
       },
       "additionalProperties": false,
@@ -1469,6 +1484,11 @@
           "required": [
             "WorkDocsConfiguration"
           ]
+        },
+        {
+          "required": [
+            "TemplateConfiguration"
+          ]
         }
       ]
     },
@@ -1492,7 +1512,8 @@
         "CONFLUENCE",
         "GOOGLEDRIVE",
         "WEBCRAWLER",
-        "WORKDOCS"
+        "WORKDOCS",
+        "TEMPLATE"
       ]
     },
     "Description": {

--- a/aws-kendra-datasource/pom.xml
+++ b/aws-kendra-datasource/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>software.amazon.cloudformation</groupId>
             <artifactId>aws-cloudformation-rpdk-java-plugin</artifactId>
-            <version>2.0.6</version>
+            <version>2.1.1</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.6</version>
+            <version>2.10.1</version>
         </dependency>
     </dependencies>
 

--- a/aws-kendra-datasource/pom.xml
+++ b/aws-kendra-datasource/pom.xml
@@ -66,6 +66,11 @@
             <version>2.26.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/Translator.java
@@ -21,6 +21,7 @@ import software.amazon.kendra.datasource.convert.S3Converter;
 import software.amazon.kendra.datasource.convert.SalesforceConverter;
 import software.amazon.kendra.datasource.convert.ServiceNowConverter;
 import software.amazon.kendra.datasource.convert.SharePointConverter;
+import software.amazon.kendra.datasource.convert.TemplateConverter;
 import software.amazon.kendra.datasource.convert.WebCrawlerConverter;
 import software.amazon.kendra.datasource.convert.WorkDocsConverter;
 import software.amazon.kendra.datasource.convert.cde.CustomDocumentEnrichmentConfigurationConverter;
@@ -233,6 +234,7 @@ public class Translator {
     modelDataSourceConfiguration.googleDriveConfiguration(GoogleDriveConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getGoogleDriveConfiguration()));
     modelDataSourceConfiguration.webCrawlerConfiguration(WebCrawlerConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getWebCrawlerConfiguration()));
     modelDataSourceConfiguration.workDocsConfiguration(WorkDocsConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getWorkDocsConfiguration()));
+    modelDataSourceConfiguration.templateConfiguration(TemplateConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getTemplateConfiguration()));
     return modelDataSourceConfiguration.build();
   }
 
@@ -258,7 +260,9 @@ public class Translator {
       return WebCrawlerConverter.toModelDataSourceConfiguration(dataSourceConfiguration.webCrawlerConfiguration());
     } else if (DataSourceType.WORKDOCS.toString().equals(dataSourceType)) {
       return WorkDocsConverter.toModelDataSourceConfiguration(dataSourceConfiguration.workDocsConfiguration());
-    } else {
+    } else if(DataSourceType.TEMPLATE.toString().equals(dataSourceType)){
+      return TemplateConverter.toModelDataSourceConfiguration(dataSourceConfiguration.templateConfiguration());
+    }else {
       return null;
     }
   }

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/TemplateConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/TemplateConverter.java
@@ -1,0 +1,40 @@
+package software.amazon.kendra.datasource.convert;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import software.amazon.awssdk.core.document.Document;
+import software.amazon.kendra.datasource.DataSourceConfiguration;
+import software.amazon.kendra.datasource.TemplateConfiguration;
+import software.amazon.kendra.datasource.utils.DocumentTypeAdapter;
+
+public class TemplateConverter {
+    private static final Gson builder = new GsonBuilder()
+            .registerTypeAdapter(Document.class, new DocumentTypeAdapter())
+            .setPrettyPrinting()
+            .create();
+
+    public static software.amazon.awssdk.services.kendra.model.TemplateConfiguration toSdkDataSourceConfiguration(TemplateConfiguration model) {
+        if (model == null) {
+            return null;
+        }
+        return software.amazon.awssdk.services.kendra.model.TemplateConfiguration.builder()
+                .template(builder.fromJson(model.getTemplate(), Document.class))
+                .build();
+    }
+
+    public static DataSourceConfiguration toModelDataSourceConfiguration(
+            software.amazon.awssdk.services.kendra.model.TemplateConfiguration templateConfiguration) {
+        return DataSourceConfiguration.builder()
+                .templateConfiguration(toModel(templateConfiguration))
+                .build();
+    }
+
+    private static TemplateConfiguration toModel(software.amazon.awssdk.services.kendra.model.TemplateConfiguration sdk) {
+        if (sdk == null) {
+            return null;
+        }
+        return TemplateConfiguration.builder()
+                .template(builder.toJson(sdk.template(), Document.class))
+                .build();
+    }
+}

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/TemplateConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/TemplateConverter.java
@@ -1,12 +1,18 @@
 package software.amazon.kendra.datasource.convert;
 
-import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+
 import software.amazon.awssdk.core.document.Document;
+import software.amazon.awssdk.core.document.internal.BooleanDocument;
+import software.amazon.awssdk.core.document.internal.ListDocument;
+import software.amazon.awssdk.core.document.internal.MapDocument;
+import software.amazon.awssdk.core.document.internal.NullDocument;
+import software.amazon.awssdk.core.document.internal.NumberDocument;
+import software.amazon.awssdk.core.document.internal.StringDocument;
 import software.amazon.kendra.datasource.DataSourceConfiguration;
 import software.amazon.kendra.datasource.TemplateConfiguration;
 import software.amazon.kendra.datasource.utils.DocumentTypeAdapter;
@@ -14,7 +20,15 @@ import software.amazon.kendra.datasource.utils.DocumentTypeAdapter;
 public class TemplateConverter {
     private static final Gson builder = new GsonBuilder()
             .registerTypeAdapter(Document.class, new DocumentTypeAdapter())
+            .registerTypeAdapter(BooleanDocument.class, new DocumentTypeAdapter())
+            .registerTypeAdapter(ListDocument.class, new DocumentTypeAdapter())
+            .registerTypeAdapter(MapDocument.class, new DocumentTypeAdapter())
+            .registerTypeAdapter(NullDocument.class, new DocumentTypeAdapter())
+            .registerTypeAdapter(NumberDocument.class, new DocumentTypeAdapter())
+            .registerTypeAdapter(StringDocument.class, new DocumentTypeAdapter())
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
             .setPrettyPrinting()
+            .serializeNulls()
             .create();
 
     public static software.amazon.awssdk.services.kendra.model.TemplateConfiguration toSdkDataSourceConfiguration(TemplateConfiguration model) {
@@ -33,13 +47,13 @@ public class TemplateConverter {
                 .build();
     }
 
-    @SuppressWarnings("unchecked") 
+    @SuppressWarnings("unchecked")
     private static TemplateConfiguration toModel(software.amazon.awssdk.services.kendra.model.TemplateConfiguration sdk) {
         if (sdk == null) {
             return null;
         }
         return TemplateConfiguration.builder()
-                .template(builder.fromJson(builder.toJson(sdk.template()), Map.class))
+                .template(builder.fromJson(builder.toJson(sdk.template().asMap()), Map.class))
                 .build();
     }
 }

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/TemplateConverter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/convert/TemplateConverter.java
@@ -1,5 +1,9 @@
 package software.amazon.kendra.datasource.convert;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import software.amazon.awssdk.core.document.Document;
@@ -18,7 +22,7 @@ public class TemplateConverter {
             return null;
         }
         return software.amazon.awssdk.services.kendra.model.TemplateConfiguration.builder()
-                .template(builder.fromJson(model.getTemplate(), Document.class))
+                .template(builder.fromJson(builder.toJson(model.getTemplate()), Document.class))
                 .build();
     }
 
@@ -29,12 +33,13 @@ public class TemplateConverter {
                 .build();
     }
 
+    @SuppressWarnings("unchecked") 
     private static TemplateConfiguration toModel(software.amazon.awssdk.services.kendra.model.TemplateConfiguration sdk) {
         if (sdk == null) {
             return null;
         }
         return TemplateConfiguration.builder()
-                .template(builder.toJson(sdk.template(), Document.class))
+                .template(builder.fromJson(builder.toJson(sdk.template()), Map.class))
                 .build();
     }
 }

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/utils/DocumentTypeAdapter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/utils/DocumentTypeAdapter.java
@@ -1,17 +1,18 @@
 package software.amazon.kendra.datasource.utils;
 
+import java.lang.reflect.Type;
+
 import com.google.gson.JsonDeserializationContext;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
+
 import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.protocols.json.internal.unmarshall.document.DocumentUnmarshaller;
 import software.amazon.awssdk.protocols.jsoncore.JsonNode;
 import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
-
-import java.lang.reflect.Type;
 
 public class DocumentTypeAdapter implements JsonDeserializer<Document>, JsonSerializer<Document> {
     private final DocumentUnmarshaller documentUnmarshaller = new DocumentUnmarshaller();
@@ -28,6 +29,12 @@ public class DocumentTypeAdapter implements JsonDeserializer<Document>, JsonSeri
     @Override
     public JsonElement serialize(
             final Document document, final Type type, final JsonSerializationContext context) {
+        if(document.isNumber()) {
+            if (document.asNumber().stringValue().contains(".")) {
+                return context.serialize(document.asNumber().doubleValue());
+            }
+            return context.serialize(document.asNumber().intValue());
+        }
         return context.serialize(document.unwrap());
     }
 }

--- a/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/utils/DocumentTypeAdapter.java
+++ b/aws-kendra-datasource/src/main/java/software/amazon/kendra/datasource/utils/DocumentTypeAdapter.java
@@ -1,0 +1,33 @@
+package software.amazon.kendra.datasource.utils;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import software.amazon.awssdk.core.document.Document;
+import software.amazon.awssdk.protocols.json.internal.unmarshall.document.DocumentUnmarshaller;
+import software.amazon.awssdk.protocols.jsoncore.JsonNode;
+import software.amazon.awssdk.protocols.jsoncore.JsonNodeParser;
+
+import java.lang.reflect.Type;
+
+public class DocumentTypeAdapter implements JsonDeserializer<Document>, JsonSerializer<Document> {
+    private final DocumentUnmarshaller documentUnmarshaller = new DocumentUnmarshaller();
+
+    @Override
+    public Document deserialize(
+            final JsonElement jsonElement, final Type type, final JsonDeserializationContext context)
+            throws JsonParseException {
+        final JsonNodeParser jsonNodeParser = JsonNodeParser.create();
+        final JsonNode jsonNode = jsonNodeParser.parse(jsonElement.toString());
+        return jsonNode.visit(documentUnmarshaller);
+    }
+
+    @Override
+    public JsonElement serialize(
+            final Document document, final Type type, final JsonSerializationContext context) {
+        return context.serialize(document.unwrap());
+    }
+}

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/TranslatorTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/TranslatorTest.java
@@ -1,6 +1,7 @@
 package software.amazon.kendra.datasource;
 
-
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.document.Document;
@@ -20,6 +21,7 @@ import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import software.amazon.awssdk.services.kendra.model.DataSourceType;
+import software.amazon.kendra.datasource.utils.DocumentTypeAdapter;
 
 public class TranslatorTest {
     private static final String DATASOURCE_CONFIGURATION =
@@ -546,5 +548,44 @@ public class TranslatorTest {
         assertThat(Translator.translateToCreateRequest(resourceModel)).isEqualTo(expected);
     }
 
+    @Test
+    void testTranslateToSdkTemplate() throws IOException {
+        DataSourceConfiguration dataSourceConfiguration = DataSourceConfiguration
+                .builder()
+                .templateConfiguration(TemplateConfiguration.builder().template(readFileFromLocal()).build())
+                .build();
 
+        assertThat(Translator.toSdkDataSourceConfiguration(dataSourceConfiguration))
+                .isEqualTo(software.amazon.awssdk.services.kendra.model.DataSourceConfiguration.builder()
+                        .templateConfiguration(software.amazon.awssdk.services.kendra.model.TemplateConfiguration.builder().
+                                template(getTemplate()).build())
+                        .build());
+    }
+
+    @Test
+    void testTranslateToCreateRequest_WithTemplateConfig() throws IOException {
+        String indexId = "indexId";
+        ResourceModel resourceModel = ResourceModel
+                .builder()
+                .indexId(indexId)
+                .type("TEMPLATE")
+                .dataSourceConfiguration(DataSourceConfiguration.builder()
+                        .templateConfiguration(TemplateConfiguration.builder().template(readFileFromLocal()).build())
+                        .build())
+                .build();
+        CreateDataSourceRequest createDataSourceRequest = Translator.translateToCreateRequest(resourceModel);
+        assertThat(createDataSourceRequest.indexId()).isEqualTo(indexId);
+        assertThat(createDataSourceRequest.configuration().templateConfiguration()).isNotNull();
+    }
+
+    private Document getTemplate() throws IOException {
+        Gson builder = new GsonBuilder()
+                .registerTypeAdapter(Document.class, new DocumentTypeAdapter())
+                .create();
+        return builder.fromJson(this.readFileFromLocal(), Document.class);
+    }
+
+    private String readFileFromLocal() throws IOException {
+        return FileUtils.readFileToString(new File(TranslatorTest.DATASOURCE_CONFIGURATION), Charset.defaultCharset());
+    }
 }

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/TemplateConverterTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/convert/TemplateConverterTest.java
@@ -1,0 +1,88 @@
+package software.amazon.kendra.datasource.convert;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.document.Document;
+import software.amazon.kendra.datasource.DataSourceConfiguration;
+import software.amazon.kendra.datasource.TemplateConfiguration;
+import software.amazon.kendra.datasource.utils.DocumentTypeAdapter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class TemplateConverterTest {
+    private static final String DATASOURCE_CONFIGURATION =
+            "testdata/datasourceconfiguration/valid_datasource_configuration.json";
+
+    @Test
+    public void testSdkDataSourceConfiguration_Null() {
+        assertThat(TemplateConverter.toSdkDataSourceConfiguration(null))
+                .isEqualTo(null);
+    }
+
+    @Test
+    public void testModelDataSourceConfiguration_Null() {
+        assertThat(TemplateConverter.toModelDataSourceConfiguration(null)
+                .getTemplateConfiguration()).isEqualTo(null);
+    }
+
+    @Test
+    public void testSDKDataSourceConfigurationWithValidConfig() throws IOException {
+        DataSourceConfiguration dataSourceConfiguration = DataSourceConfiguration.builder()
+                .templateConfiguration(TemplateConfiguration.builder()
+                        .template(readFileFromLocal(DATASOURCE_CONFIGURATION))
+                        .build())
+                .build();
+
+        software.amazon.awssdk.services.kendra.model.TemplateConfiguration expectedDataSourceConfiguration =
+                software.amazon.awssdk.services.kendra.model.TemplateConfiguration.builder()
+                        .template(getTemplate(DATASOURCE_CONFIGURATION)).build();
+
+        assertThat(TemplateConverter.toSdkDataSourceConfiguration(dataSourceConfiguration.getTemplateConfiguration()))
+                .isEqualTo(expectedDataSourceConfiguration);
+
+    }
+
+    @Test
+    public void testModelDataSourceConfigurationWithValidConfig() throws IOException {
+        software.amazon.awssdk.services.kendra.model.TemplateConfiguration sdkDataSourceConfiguration =
+                software.amazon.awssdk.services.kendra.model.TemplateConfiguration.builder()
+                        .template(getTemplate(DATASOURCE_CONFIGURATION)).build();
+
+        DataSourceConfiguration expectedDataSourceConfiguration = DataSourceConfiguration.builder()
+                .templateConfiguration(TemplateConfiguration.builder()
+                        .template(readFileFromLocal(DATASOURCE_CONFIGURATION))
+                        .build())
+                .build();
+
+        Gson gson = new Gson();
+        DataSourceConfiguration result = TemplateConverter.toModelDataSourceConfiguration(sdkDataSourceConfiguration);
+        JsonObject resultTemplateConfig = gson.fromJson(result.getTemplateConfiguration().getTemplate(), JsonObject.class);
+
+        JsonObject expectedDataSourceConfigurationTemplateConfig = gson.fromJson(
+            expectedDataSourceConfiguration.getTemplateConfiguration().getTemplate(), JsonObject.class
+        );
+
+        assertThat(expectedDataSourceConfigurationTemplateConfig)
+                .isEqualTo(resultTemplateConfig);
+    }
+
+    private Document getTemplate(String filePath) throws IOException {
+        Gson builder = new GsonBuilder()
+                .registerTypeAdapter(Document.class, new DocumentTypeAdapter())
+                .create();
+        return builder.fromJson(this.readFileFromLocal(filePath), Document.class);
+    }
+
+    private String readFileFromLocal(String filePath) throws IOException {
+        return FileUtils.readFileToString(new File(filePath), Charset.defaultCharset());
+    }
+}

--- a/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/utils/DocumentTypeAdapterTest.java
+++ b/aws-kendra-datasource/src/test/java/software/amazon/kendra/datasource/utils/DocumentTypeAdapterTest.java
@@ -1,0 +1,35 @@
+package software.amazon.kendra.datasource.utils;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.document.Document;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DocumentTypeAdapterTest {
+
+    private static final String TYPE = "type";
+
+    private static final String SERIALIZED_DOCUMENT = "{\"type\":\"test\"}";
+    private static final Document DOCUMENT = Document.mapBuilder().putString(TYPE, "test").build();
+    private Gson gson;
+
+    @BeforeEach
+    void setup() {
+        this.gson = new GsonBuilder()
+                .registerTypeAdapter(Document.class, new DocumentTypeAdapter())
+                .create();
+    }
+
+    @Test
+    public void documentSerialization_valid_argument_success() {
+        assertEquals(SERIALIZED_DOCUMENT, gson.toJson(DOCUMENT, Document.class));
+    }
+
+    @Test
+    public void documentDeserialization_valid_argument_success() {
+        assertEquals(DOCUMENT, gson.fromJson(SERIALIZED_DOCUMENT, Document.class));
+    }
+}

--- a/aws-kendra-datasource/testdata/datasourceconfiguration/valid_datasource_configuration.json
+++ b/aws-kendra-datasource/testdata/datasourceconfiguration/valid_datasource_configuration.json
@@ -75,5 +75,9 @@
     "isCrawlCommunityTopic": "true",
     "isCrawlCommunityPost": "true",
     "isCrawlCommunityPostComment": "true"
-  }
+  },
+  "booleanValue": true,
+  "numberValue": 1.23,
+  "integerValue": 123,
+  "nullValue": null
 }


### PR DESCRIPTION
*Issue #, if available:* #107

*Description of changes:*
I reimplement the templateConfiguration property that was reverted in #107. Unlike past implementations that were implemented in string types, Template properties are implemented in object types, so the user's development experience is also better compared to string types.
In the past, the CloudFormation CLI Java Plugin did not implement the Document type, so it was a string type implementation, but since it was implemented with the CloudFormation CLI Java Plugin v2.1.0, it is now possible.
https://github.com/aws-cloudformation/cloudformation-cli-java-plugin/releases/tag/v2.1.0-plugin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
