### PR TITLE
Add LanguageCode to FAQ resource.

### DIFF
--- a/aws-kendra-faq/aws-kendra-faq.json
+++ b/aws-kendra-faq/aws-kendra-faq.json
@@ -46,6 +46,13 @@
       "minLength": 1,
       "maxLength": 1000
     },
+    "LanguageCode": {
+      "description": "The code for a language.",
+      "type": "string",
+      "minLength": 2,
+      "maxLength": 10,
+      "pattern": "[a-zA-Z-]*"
+    },
     "FileFormat": {
       "description": "Format of the input file",
       "enum": [
@@ -135,6 +142,9 @@
     "Arn": {
       "type": "string",
       "maxLength": 1000
+    },
+    "LanguageCode": {
+      "$ref": "#/definitions/LanguageCode"
     }
   },
   "required": [

--- a/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/Translator.java
+++ b/aws-kendra-faq/src/main/java/software/amazon/kendra/faq/Translator.java
@@ -35,7 +35,8 @@ public class Translator {
             .description(model.getDescription())
             .name(model.getName())
             .roleArn(model.getRoleArn())
-            .fileFormat(model.getFileFormat());
+            .fileFormat(model.getFileFormat())
+            .languageCode(model.getLanguageCode());
     if (model.getS3Path() != null) {
       builder.s3Path(
               S3Path.builder()
@@ -65,7 +66,8 @@ public class Translator {
             .description(describeFaqResponse.description())
             .name(describeFaqResponse.name())
             .roleArn(describeFaqResponse.roleArn())
-            .fileFormat(describeFaqResponse.fileFormatAsString());
+            .fileFormat(describeFaqResponse.fileFormatAsString())
+            .languageCode(describeFaqResponse.languageCode());
     if (describeFaqResponse.s3Path() != null) {
       builder.s3Path(software.amazon.kendra.faq.S3Path.builder()
               .key(describeFaqResponse.s3Path().key())

--- a/aws-kendra-faq/src/test/java/software/amazon/kendra/faq/TranslatorTest.java
+++ b/aws-kendra-faq/src/test/java/software/amazon/kendra/faq/TranslatorTest.java
@@ -42,6 +42,7 @@ class TranslatorTest {
                 .s3Path(s3Path)
                 .roleArn(roleArn)
                 .tags(Arrays.asList(Tag.builder().key(tagKey).value(tagValue).build()))
+                .languageCode("de")
                 .build();
 
         CreateFaqRequest createFaqRequest = CreateFaqRequest
@@ -56,6 +57,7 @@ class TranslatorTest {
                         .bucket(s3Bucket)
                         .build())
                 .roleArn(roleArn)
+                .languageCode("de")
                 .tags(Arrays.asList(software.amazon.awssdk.services.kendra.model.Tag
                         .builder().key(tagKey).value(tagValue).build()))
                 .build();


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kendra/pull/106

*Description of changes:*
This PR adds the LanguageCode property to the FAQ resource.

---
## Testing
1. Create a Kendra Index (see: https://docs.aws.amazon.com/kendra/latest/dg/create-index.html)
1. Create a role for the FAQ (see: https://docs.aws.amazon.com/kendra/latest/dg/iam-roles.html)
1. Upload an FAQ file to the s3 bucket (in this example, I call it faq.csv)
1. Create an FAQ in CloudFormation for the Index with LanguageCode specified
   ```yml
   AWSTemplateFormatVersion: 2010-09-09
   Resources:
      TheFaq:
       Type: 'AWS::Kendra::Faq'
       Properties:
         Name: 'DerFaqVeryFaq'
         Description: 'Dies ist eine FAQ-Datei'
         LanguageCode: "de"
         RoleArn: <Your Role ARN here>
         IndexId: <Your Index ID here>
         S3Path:
           Bucket: <Your bucket name here>
           Key: 'faq.csv'
   ```
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
