### PR TITLE
Update rpdk config runtime

### DIFF
--- a/aws-kendra-datasource/.rpdk-config
+++ b/aws-kendra-datasource/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Kendra::DataSource",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "software.amazon.kendra.datasource.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.kendra.datasource.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-kendra-datasource/template.yml
+++ b/aws-kendra-datasource/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.datasource.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-datasource-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.datasource.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-datasource-handler-1.0-SNAPSHOT.jar

--- a/aws-kendra-faq/.rpdk-config
+++ b/aws-kendra-faq/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Kendra::Faq",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "software.amazon.kendra.faq.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.kendra.faq.HandlerWrapper::testEntrypoint",
     "settings": {
@@ -12,8 +12,8 @@
             "kendra",
             "faq"
         ],
-	"codegen_template_path": "guided_aws",
-	"protocolVersion": "2.0.0"
+        "codegen_template_path": "guided_aws",
+        "protocolVersion": "2.0.0"
     },
     "logProcessorEnabled": "true",
     "executableEntrypoint": "software.amazon.kendra.faq.HandlerWrapperExecutable"

--- a/aws-kendra-faq/template.yml
+++ b/aws-kendra-faq/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.faq.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-faq-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.faq.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-faq-handler-1.0-SNAPSHOT.jar

--- a/aws-kendra-featuredresultsset/.rpdk-config
+++ b/aws-kendra-featuredresultsset/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Kendra::FeaturedResultsSet",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "software.amazon.kendra.featuredresultsset.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.kendra.featuredresultsset.HandlerWrapper::testEntrypoint",
     "settings": {
@@ -24,5 +24,6 @@
         "codegen_template_path": "guided_aws",
         "protocolVersion": "2.0.0"
     },
+    "logProcessorEnabled": "true",
     "executableEntrypoint": "software.amazon.kendra.featuredresultsset.HandlerWrapperExecutable"
 }

--- a/aws-kendra-featuredresultsset/template.yml
+++ b/aws-kendra-featuredresultsset/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.featuredresultsset.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-featuredresultsset-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.featuredresultsset.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-featuredresultsset-handler-1.0-SNAPSHOT.jar

--- a/aws-kendra-index/.rpdk-config
+++ b/aws-kendra-index/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "AWS::Kendra::Index",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java8.al2",
     "entrypoint": "software.amazon.kendra.index.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.kendra.index.HandlerWrapper::testEntrypoint",
     "settings": {

--- a/aws-kendra-index/template.yml
+++ b/aws-kendra-index/template.yml
@@ -12,12 +12,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.index.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-index-handler-1.0-SNAPSHOT.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.kendra.index.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java8.al2
       CodeUri: ./target/aws-kendra-index-handler-1.0-SNAPSHOT.jar


### PR DESCRIPTION
Update resource config runtimes to java8.al2

*Issue #, if available:*

N/A

*Description of changes:*
Update to use Java8 Al2.
See: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtime-support-policy

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
